### PR TITLE
magic damage types now available on OLC

### DIFF
--- a/lib/world/obj/30.obj
+++ b/lib/world/obj/30.obj
@@ -282,7 +282,7 @@ A small sword lies here.~
 Nothing.
 ~
 5 1060864 8193 1
-0 1 6 3 0 0 0
+0 1 6 15 0 0 0
 8.00 60 0 0 0 0 0 0
 E
 small sword~
@@ -431,7 +431,6 @@ A short cane is resting here in the way.~
 3 0 16385 1
 20 1 1 3 0 0 0
 2.00 0 0 0 0 0 0 0
-T 6019
 E
 cane mayor short mayors-cane questobject~
 The mayor's cane is simply a short piece of wood to help him with walking in
@@ -1709,7 +1708,6 @@ A miniature elephant with curved tusks and thick wooly hair sits here waiting fo
 12 13552640 16385 30
 0 0 0 0 0 0 0
 0.50 200000 0 0 0 0 0 0
-T 18887
 E
 doll miniature-mammoth-doll miniature-elephant~
 Mammoths are gigantic elephants covered in thick wooly hair.  Although not
@@ -1821,7 +1819,6 @@ An itty-bitty pillar of flame dances across the floor.~
 1 12632064 16385 40
 0 -1 -1 0 0 0 0
 0.50 250000 0 0 0 0 0 0
-T 18887
 E
 doll miniature-flame-elemental-doll itty-bitty-pillar-flame~
 This soft little doll is sewn in the shape of a flame, with varying shades of
@@ -1853,7 +1850,6 @@ A plump little demon stares off into the swirling nothingness.~
 3 13680704 16385 50
 50 10 10 2 0 0 0
 0.50 150000 0 0 0 0 0 0
-T 18887
 E
 doll miniature-krisenna-doll plump-little-demon~
 The demon stands at least twice as tall the average doll.  He has little
@@ -2869,7 +2865,6 @@ A broad silver belt has been left here.~
 9 64 2049 10
 6 0 0 0 0 0 0
 2.00 1200 0 0 0 0 0 0
-T 1299
 E
 belt silver~
 It is a broad belt made from tiny silver rings woven together.

--- a/src/act.wizinfo.c
+++ b/src/act.wizinfo.c
@@ -415,7 +415,7 @@ void do_stat_object(struct char_data *ch, struct obj_data *j) {
     case ITEM_WEAPON:
         str_catf(buf, "Todam: %dd%d (avg %.1f), Message type: %d, '%s'\r\n", GET_OBJ_VAL(j, VAL_WEAPON_DICE_NUM),
                  GET_OBJ_VAL(j, VAL_WEAPON_DICE_SIZE), WEAPON_AVERAGE(j), GET_OBJ_VAL(j, VAL_WEAPON_DAM_TYPE),
-                 GET_OBJ_VAL(j, VAL_WEAPON_DAM_TYPE) >= 0 && GET_OBJ_VAL(j, VAL_WEAPON_DAM_TYPE) <= TYPE_STAB - TYPE_HIT
+                 GET_OBJ_VAL(j, VAL_WEAPON_DAM_TYPE) >= 0 && GET_OBJ_VAL(j, VAL_WEAPON_DAM_TYPE) <= TYPE_POISON - TYPE_HIT
                      ? attack_hit_text[GET_OBJ_VAL(j, VAL_WEAPON_DAM_TYPE)].singular
                      : "<&1INVALID&0>");
         break;

--- a/src/fight.c
+++ b/src/fight.c
@@ -83,7 +83,9 @@ struct attack_hit_type attack_hit_text[] = {{"hit", "hits"}, /* 0 */
                                             {"crush", "crushes"},  {"pound", "pounds"},       {"claw", "claws"},
                                             {"maul", "mauls"},     {"thrash", "thrashes"}, /* 10 */
                                             {"pierce", "pierces"}, {"blast", "blasts"},       {"punch", "punches"},
-                                            {"stab", "stabs"}};
+                                            {"stab", "stabs"},     {"burn", "burns"},      /* 15 */
+                                            {"freeze", "freezes"}, {"corrode", "corrodes"},   {"shock", "shocks"},
+                                            {"poison", "poisons"}};
 
 /****************************/
 /*  General target linking  */
@@ -2000,6 +2002,11 @@ int weapon_proficiency(struct obj_data *weapon, int position) {
     case TYPE_THRASH:
     case TYPE_PUNCH:
     case TYPE_BLAST:
+    case TYPE_FIRE:
+    case TYPE_COLD:
+    case TYPE_ACID:
+    case TYPE_SHOCK:
+    case TYPE_POISON:
         return -1;
 
         /* These are slashing weapons. */

--- a/src/objects.c
+++ b/src/objects.c
@@ -108,7 +108,7 @@ const struct obj_type_def item_types[NUM_ITEM_TYPES] = {
         {{0, 40},
          {0, 20},
          {0, 20},
-         {0, TYPE_STAB - TYPE_HIT},
+         {0, TYPE_POISON - TYPE_HIT},
          {VAL_MIN, VAL_MAX},
          {VAL_MIN, VAL_MAX},
          {VAL_MIN, VAL_MAX}},

--- a/src/objects.h
+++ b/src/objects.h
@@ -431,6 +431,16 @@ struct obj_data {
      (GET_OBJ_VAL(obj, VAL_WEAPON_DAM_TYPE) == TYPE_MAUL - TYPE_HIT) ||                                                \
      (GET_OBJ_VAL(obj, VAL_WEAPON_DAM_TYPE) == TYPE_POUND - TYPE_HIT) ||                                               \
      (GET_OBJ_VAL(obj, VAL_WEAPON_DAM_TYPE) == TYPE_CRUSH - TYPE_HIT))
+#define IS_WEAPON_FIRE(obj)                                                                                            \
+    ((GET_OBJ_VAL(obj, VAL_WEAPON_DAM_TYPE) == TYPE_FIRE - TYPE_HIT))
+#define IS_WEAPON_COLD(obj)                                                                                            \
+    ((GET_OBJ_VAL(obj, VAL_WEAPON_DAM_TYPE) == TYPE_COLD - TYPE_HIT))
+#define IS_WEAPON_ACID(obj)                                                                                            \
+    ((GET_OBJ_VAL(obj, VAL_WEAPON_DAM_TYPE) == TYPE_ACID - TYPE_HIT))
+#define IS_WEAPON_SHOCK(obj)                                                                                           \
+    ((GET_OBJ_VAL(obj, VAL_WEAPON_DAM_TYPE) == TYPE_SHOCK - TYPE_HIT))
+#define IS_WEAPON_POISON(obj)                                                                                          \
+    ((GET_OBJ_VAL(obj, VAL_WEAPON_DAM_TYPE) == TYPE_POISON - TYPE_HIT))
 
 #define OBJ_IS_OPENABLE(obj)                                                                                           \
     (GET_OBJ_TYPE(obj) == ITEM_CONTAINER && IS_SET(GET_OBJ_VAL(obj, VAL_CONTAINER_BITS), CONT_CLOSEABLE))

--- a/src/oedit.c
+++ b/src/oedit.c
@@ -1089,7 +1089,7 @@ void oedit_disp_obj_values(struct descriptor_data *d) {
                 "       Message : %s%s%s\r\n",
                 cyn, GET_OBJ_VAL(obj, VAL_WEAPON_DICE_NUM), GET_OBJ_VAL(obj, VAL_WEAPON_DICE_SIZE), nrm, cyn,
                 GET_OBJ_VAL(obj, VAL_WEAPON_DAM_TYPE) >= 0 &&
-                        GET_OBJ_VAL(obj, VAL_WEAPON_DAM_TYPE) <= TYPE_STAB - TYPE_HIT
+                        GET_OBJ_VAL(obj, VAL_WEAPON_DAM_TYPE) <= TYPE_POISON - TYPE_HIT
                     ? attack_hit_text[GET_OBJ_VAL(obj, VAL_WEAPON_DAM_TYPE)].singular
                     : "INVALID",
                 nrm);

--- a/src/olc.h
+++ b/src/olc.h
@@ -32,7 +32,7 @@
 
 /*. CONFIG DEFINES - these should be in structs.h, but here is easyer.*/
 
-#define NUM_ATTACK_TYPES 15
+#define NUM_ATTACK_TYPES 20
 
 #define NUM_SHOP_FLAGS 2
 #define NUM_TRADERS 7

--- a/src/spec_procs.c
+++ b/src/spec_procs.c
@@ -956,7 +956,7 @@ int red_recall_room(struct char_data *ch) {
         room = 6222;
         break;
 
-    case CLASS_BERSERKER;
+    case CLASS_BERSERKER:
         room = 55796;
         break;
 

--- a/src/vsearch.c
+++ b/src/vsearch.c
@@ -964,7 +964,7 @@ ACMD(do_msearch) {
             return;
         /* Special handling for 18: attack type */
         if (mode == 18) {
-            for (found = temp = 0; temp <= TYPE_STAB - TYPE_HIT; ++temp)
+            for (found = temp = 0; temp <= TYPE_POISON - TYPE_HIT; ++temp)
                 if (is_abbrev(string, attack_hit_text[temp].plural)) {
                     found = 1;
                     value = temp;
@@ -1226,7 +1226,7 @@ ACMD(do_osearch) {
 
         /* Special handling for 25: attack type */
         if (mode == 25) {
-            for (found = temp = 0; temp <= TYPE_STAB - TYPE_HIT; ++temp)
+            for (found = temp = 0; temp <= TYPE_POISON - TYPE_HIT; ++temp)
                 if (is_abbrev(string, attack_hit_text[temp].plural)) {
                     found = 1;
                     value = temp;


### PR DESCRIPTION
Allows fire, cold, acid, shock, and poison damage types on weapons!