### PR TITLE
altered bless-type spells and effects

### DIFF
--- a/src/fight.c
+++ b/src/fight.c
@@ -2074,6 +2074,23 @@ void hit(struct char_data *ch, struct char_data *victim, int type) {
         calc_thaco -= (GET_SKILL(ch, SKILL_BAREHAND) / 2);
     }
 
+    /* check for bless/hex - VALUES: 0 to 20 */
+    if (EFF_FLAGGED(ch, EFF_BLESS) || EFF_FLAGGED(ch, EFF_HEX)) {
+        if (IS_GOOD(ch) && IS_EVIL(victim)) 
+            calc_thaco -= GET_LEVEL(ch) / 5; /* good characters get a big bonus to attacking evil characters */
+        if (IS_GOOD(ch) && IS_NEUTRAL(victim))
+            calc_thaco -= GET_LEVEL(ch) / 10; /* good characters get a smaller bonus to attacking neutral characters */
+        if (IS_GOOD(ch) && IS_GOOD(victim))
+            calc_thaco += GET_LEVEL(ch) / 10; /* good characters get a small penalty to attacking good characters */
+        if (IS_EVIL(ch) && IS_GOOD(victim))
+            calc_thaco -= GET_LEVEL(ch) / 5; /* evil characters get a big bonus to attacking good characters */
+        if (IS_EVIL(ch) && IS_NEUTRAL(victim))
+            calc_thaco -= GET_LEVEL(ch) / 5; /* evil characters get a small bonus to attacking neutral characters */
+        if (IS_EVIL(ch) && IS_EVIL(victim))
+            calc_thaco += GET_LEVEL(ch) / 10; /* evil characters get a small penalty to attacking evil characters */
+        if (IS_NEUTRAL(ch) && !IS_NEUTRAL(victim))
+            calc_thaco -= GET_LEVEL(ch) / 10; /* neutral characters get a small bonus to attacking good or evil characters */
+    }
     /* calc_thaco ranges from 290 to -290 */
     diceroll = number(1, 200);
 

--- a/src/magic.c
+++ b/src/magic.c
@@ -1198,17 +1198,35 @@ int mag_affect(int skill, struct char_data *ch, struct char_data *victim, int sp
             return CAST_RESULT_CHARGE;
         }
 
-        eff[0].location = APPLY_HITROLL;
-        eff[0].modifier = 1 + (skill >= 50);
+        eff[0].location = APPLY_SAVING_SPELL;
+        eff[0].modifier = -2 - (skill / 10);
         eff[0].duration = 10 + (skill / 7); /* 10-24 hrs */
-        eff[1].location = APPLY_SAVING_SPELL;
-        eff[1].modifier = -2 - (skill / 10);
-        eff[1].duration = eff[0].duration;
+        if (skill < 55) {
+            to_char = "$N is inspired by your gods.";
+            to_vict = "Your inner angel is inspired by $n.\r\nYou feel righteous.";
+            if (ch == victim)
+                to_room =
+                    "$n is inspired to do good.";
+            else
+                to_room =
+                    "$N is inspired to do good by $n.";
+        } else {
+            eff[1].location = APPLY_DAMROLL;
+            eff[1].modifier = 1 + (skill > 95);
+            eff[1].duration = eff[0].duration;
+            to_char = "$N is inspired by your gods in divine euphoria!";
+            to_vict = "Your inner angel is inspired by $n.\r\nYou feel a wave of divine euphoria!";
+            if (ch == victim)
+                to_room =
+                    "$n is inspired to do good.\r"
+                    "\n$n is overcome with divine euphoria!";
+            else
+                to_room =
+                    "$N is inspired to do good by $n.\r"
+                    "\n$N is overcome with divine euphoria!";
+        }
         SET_FLAG(eff[2].flags, EFF_BLESS);
         eff[2].duration = eff[0].duration;
-        to_char = "$N is inspired by your gods.";
-        to_vict = "Your inner angel is inspired by $n.\r\nYou feel righteous.";
-        to_room = "$N is inspired to do good by $n.";
         break;
 
     case SPELL_BLINDNESS:
@@ -1583,17 +1601,35 @@ int mag_affect(int skill, struct char_data *ch, struct char_data *victim, int sp
             return CAST_RESULT_CHARGE;
         }
 
-        eff[0].location = APPLY_HITROLL;
-        eff[0].modifier = 1 + (skill >= 50);
+        eff[0].location = APPLY_SAVING_SPELL;
+        eff[0].modifier = -2 - (skill / 10);
         eff[0].duration = 10 + (skill / 7); /* 10-24 hrs */
-        eff[1].location = APPLY_SAVING_SPELL;
-        eff[1].modifier = -2 - (skill / 10);
-        eff[1].duration = eff[0].duration;
+        if (skill < 55) {
+            to_char = "$N is imbued with the power of nature.";
+            to_vict = "$n imbues you with the power of nature.";
+            if (ch == victim)
+                to_room =
+                    "$N is imbued with the power of nature.";
+            else
+                to_room =
+                    "$N is imbued with the power of nature by $n.";
+        } else {
+            eff[1].location = APPLY_DAMROLL;
+            eff[1].modifier = 1 + (skill > 95);
+            eff[1].duration = eff[0].duration;
+            to_char = "$N is imbued with the glorious might of nature!";
+            to_vict = "$n imbues you with nature's glory!\r\nYou feel supernaturally mighty!";
+            if (ch == victim)
+                to_room =
+                    "$N is imbued with nature's glory!\r"
+                    "\n$n is bolstered with supernatural might!";
+            else
+                to_room =
+                    "$N is imbued with nature's glory by $n!\r"
+                    "\n$N is bolstered with supernatural might!";
+        }
         SET_FLAG(eff[2].flags, EFF_BLESS);
         eff[2].duration = eff[0].duration;
-        to_char = "$N is imbued with the power of nature.";
-        to_vict = "$n imbues you with the power of nature.\r\nYou feel righteous.";
-        to_room = "$N is imbued with the power of nature by $n.";
         break;
 
     case SPELL_ELEMENTAL_WARDING:


### PR DESCRIPTION
Alters the Bless, Earth Blessing, and Dark Presence spells so they now all increase Spell Save, and Damage Roll at the highest end.

Hitroll changes are now controlled by the existence of the Bless and Hex flags, which do the same thing: increase hitroll by 20% of level against creatures of opposite alignment, increase hitroll by 10% of level against creatures of neutral alignment, and DECREASE hitroll by 10% against creatures of same alignment.  Neutral characters will gain 10% against good and evil targets, but suffer no penalty against neutral ones.