### PR TITLE
changed punctuation in a half-elf field

### DIFF
--- a/src/races.cpp
+++ b/src/races.cpp
@@ -354,7 +354,7 @@ RaceDef races[NUM_RACES] = {
      nullptr,
      {0, 0}},
     /* HALF-ELF */
-    {"half_elf",
+    {"halfelf",
      "half-elf half elf",
      "&6&bHalf-&0&6&dElf&0",
      "&6&bHalf-&0&6&dElf&0",

--- a/src/races.cpp
+++ b/src/races.cpp
@@ -354,7 +354,7 @@ RaceDef races[NUM_RACES] = {
      nullptr,
      {0, 0}},
     /* HALF-ELF */
-    {"half-elf",
+    {"half_elf",
      "half-elf half elf",
      "&6&bHalf-&0&6&dElf&0",
      "&6&bHalf-&0&6&dElf&0",
@@ -1480,7 +1480,7 @@ int parse_race(CharData *ch, CharData *vict, char *arg) {
 
     if (!races[race].playable) {
         if (ch) {
-            char_printf(ch, "The {} race is not available to mortals.\n", races[race].name);
+            char_printf(ch, "The {} race is not available to mortals.\n", races[race].plainname);
         }
         return RACE_UNDEFINED;
     }


### PR DESCRIPTION
I made this change to help with writing triggers.  This way the script can check for half_elf instead of half-elf, which will ease the burden of matching mob race.