### PR TITLE
commented out code that was causing any use of hit() to switch without message

### DIFF
--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -1978,13 +1978,6 @@ void hit(CharData *ch, CharData *victim, int type) {
         return;
     }
 
-    /* DO NOT DO THIS -- Caller should go through set_battling(), as noted at top of page.
-    Target switches should be checked in the individual command or function with switch_ok(), not here */
-
-    /* If you were fighting someone else, you're going to switch targets. 
-    if (ch->target && ch->target != victim)
-        stop_fighting(ch); */
-
     aggro_lose_spells(ch);
 
     /* See if anyone is guarding the victim.

--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -1978,9 +1978,12 @@ void hit(CharData *ch, CharData *victim, int type) {
         return;
     }
 
-    /* If you were fighting someone else, you're going to switch targets. */
+    /* DO NOT DO THIS -- Caller should go through set_battling(), as noted at top of page.
+    Target switches should be checked in the individual command or function with switch_ok(), not here */
+
+    /* If you were fighting someone else, you're going to switch targets. 
     if (ch->target && ch->target != victim)
-        stop_fighting(ch);
+        stop_fighting(ch); */
 
     aggro_lose_spells(ch);
 


### PR DESCRIPTION
Not sure when this was implemented, but it's the reason hitall and riposte were switching targets without a message.

The code at the top of fight.cpp clearly says only the set_battling function should allow targets to switch, which should be checked by switch_ok within the specific command/function that initiates the attack.

I've only commented out the code in case there's a real reason to use it so we can quickly restore and change the comments in the doc.