### PR TITLE
drop triggers now work on containers

### DIFF
--- a/include/dg_scripts.hpp
+++ b/include/dg_scripts.hpp
@@ -166,7 +166,7 @@ int entry_mtrigger(CharData *ch, int destination);
 int preentry_wtrigger(RoomData *room, CharData *actor, int dir);
 int postentry_wtrigger(CharData *actor, int dir);
 int timer_otrigger(ObjData *obj);
-int drop_otrigger(ObjData *obj, CharData *actor);
+int drop_otrigger(ObjData *obj, CharData *actor, ObjData *cont);
 int get_otrigger(ObjData *obj, CharData *actor);
 int drop_wtrigger(ObjData *obj, CharData *actor);
 int give_otrigger(ObjData *obj, CharData *actor, CharData *victim);

--- a/src/act.item.cpp
+++ b/src/act.item.cpp
@@ -77,7 +77,7 @@ int conceal_roll(CharData *ch, ObjData *obj) {
 }
 
 void perform_put(CharData *ch, ObjData *obj, ObjData *cont) {
-    if (!drop_otrigger(obj, ch))
+    if (!drop_otrigger(obj, ch, cont) || !drop_otrigger(cont, ch, obj))
         return;
     if (GET_OBJ_EFFECTIVE_WEIGHT(cont) + GET_OBJ_EFFECTIVE_WEIGHT(obj) > GET_OBJ_VAL(cont, VAL_CONTAINER_CAPACITY))
         act("$p won't fit in $P.", false, ch, obj, cont, TO_CHAR);
@@ -210,7 +210,7 @@ ACMD(do_stow) {
                 char_printf(ch, "You aren't carrying {} {}.\n", AN(arg1), arg1);
             else if (obj == cont)
                 char_printf(ch, "You attempt to fold it into itself, but fail.\n");
-            else if (!drop_otrigger(obj, ch))
+            else if (!drop_otrigger(obj, ch, cont))
                 return;
             else if (OBJ_FLAGGED(obj, ITEM_NODROP))
                 act("You can't stow $p in $P because it's CURSED!", false, ch, obj, cont, TO_CHAR);
@@ -283,7 +283,7 @@ void perform_drop(CharData *ch, ObjData *obj, byte mode, const char *verb) {
      * trigger to go off. */
 
     if (mode == SCMD_DROP || mode == SCMD_LETDROP) {
-        if (!drop_otrigger(obj, ch))
+        if (!drop_otrigger(obj, ch, nullptr))
             return;
         if (!drop_wtrigger(obj, ch))
             return;

--- a/src/dg_triggers.cpp
+++ b/src/dg_triggers.cpp
@@ -771,7 +771,7 @@ int death_otrigger(CharData *actor) {
     return 1;
 }
 
-int drop_otrigger(ObjData *obj, CharData *actor) {
+int drop_otrigger(ObjData *obj, CharData *actor, ObjData *target) {
     TrigData *t;
     char buf[MAX_INPUT_LENGTH];
 
@@ -781,6 +781,8 @@ int drop_otrigger(ObjData *obj, CharData *actor) {
     for (t = TRIGGERS(SCRIPT(obj)); t; t = t->next) {
         if (TRIGGER_CHECK(t, OTRIG_DROP) && (random_number(1, 100) <= GET_TRIG_NARG(t))) {
             ADD_UID_VAR(buf, t, actor, "actor");
+            if (target)
+                ADD_UID_VAR(buf, t, target, "target");
             /* Don't allow a drop to take place, if the object is purged. */
             return (script_driver(&obj, t, OBJ_TRIGGER, TRIG_NEW) && obj);
         }


### PR DESCRIPTION
As it turns out, drop triggers already run when an item is placed in another object if the trigger is on the item being placed.  This modification expands drop triggers to run on containers when items are put into them.

It also adds the UID variable "target". 
- If the trigger running is on the **item** being placed in a container, "target" is the _container the object is placed in_.  
- If the trigger running is on the **container** an object is being place in, "target" is the _object being put in the container_.
- If an item is just being dropped, "target" is not retained.