### PR TITLE
creates the instrument magic item type and a use trigger

### DIFF
--- a/include/casting.hpp
+++ b/include/casting.hpp
@@ -28,6 +28,7 @@
 #define CAST_BREATH 5
 #define CAST_CHANT 6
 #define CAST_PERFORM 7
+#define CAST_INSTRUMENT 8
 
 #define CAST_RESULT_CHARGE (1 << 0)
 #define CAST_RESULT_IMPROVE (1 << 1)

--- a/include/defines.hpp
+++ b/include/defines.hpp
@@ -1052,7 +1052,8 @@
 #define ITEM_WALL 27       /* Blocks passage in one direction */
 #define ITEM_TOUCHSTONE 28 /* Item sets homeroom when touched */
 #define ITEM_BOARD 29
-#define NUM_ITEM_TYPES 30
+#define ITEM_INSTRUMENT 30 /* Item is a musical instrument    */
+#define NUM_ITEM_TYPES 31
 
 /* Take/Wear flags: used by ObjData.obj_flags.wear_flags */
 #define ITEM_WEAR_TAKE (1 << 0)     /* Item can be takes         */

--- a/include/dg_scripts.hpp
+++ b/include/dg_scripts.hpp
@@ -62,6 +62,7 @@
 #define OTRIG_DEATH (1u << 10u)   /* character dies             */
 #define OTRIG_REMOVE (1u << 11u)  /* character tries to remove obj */
 #define OTRIG_LOOK (1u << 12u)    /* object is looked at        */
+#define OTRIG_USE (1u << 13u)     /* object is used             */
 #define OTRIG_LOAD (1u << 14u)    /* the object is loaded       */
 #define OTRIG_CAST (1u << 15u)    /* object targeted by spell  */
 #define OTRIG_LEAVE (1u << 16u)   /* some leaves room seen      */
@@ -201,6 +202,8 @@ void time_wtrigger(RoomData *room);
 
 int look_otrigger(ObjData *obj, CharData *actor, char *arg, const char *additional_args);
 int look_mtrigger(CharData *ch, CharData *actor, const char *arg);
+
+int use_otrigger(ObjData *obj, ObjData *tobj, CharData *actor, CharData *victim);
 
 void reset_wtrigger(RoomData *room);
 

--- a/include/interpreter.hpp
+++ b/include/interpreter.hpp
@@ -246,6 +246,7 @@ void free_aliases(AliasData *alias_list);
 #define SCMD_USE 0
 #define SCMD_QUAFF 1
 #define SCMD_RECITE 2
+#define SCMD_PLAY 3
 
 /* do_echo */
 #define SCMD_ECHO 0

--- a/include/objects.hpp
+++ b/include/objects.hpp
@@ -465,6 +465,18 @@ const struct ObjectTypeDef item_types[NUM_ITEM_TYPES] = {
          {VAL_MIN, VAL_MAX},
          {VAL_MIN, VAL_MAX}},
     },
+
+    {
+        "INSTRUMENT",
+        "an instrument",
+        {{0, LVL_IMMORT},
+         {0, 20},
+         {0, 20},
+         {0, MAX_SPELLS},
+         {VAL_MIN, VAL_MAX},
+         {VAL_MIN, VAL_MAX},
+         {VAL_MIN, VAL_MAX}},
+    },
 };
 
 const struct LiquidDef liquid_types[NUM_LIQ_TYPES] = {

--- a/scripts/mud/flags.py
+++ b/scripts/mud/flags.py
@@ -298,6 +298,7 @@ OBJECT_TYPES = [
     "WALL",  # 27,  # /* Blocks passage in one direction */
     "TOUCHSTONE",  # 28,  # /* Item sets homeroom when touched */
     "BOARD",  # 29,  # Bullitin board
+    "INSTRUMENT", # 30, # /* Item is a musical instrument */
 ]
 
 WEAR_FLAGS = [

--- a/scripts/mud/obj.py
+++ b/scripts/mud/obj.py
@@ -111,7 +111,7 @@ class Obj(Base):
                     'Spell 2': Obj.get_flag(args[2], SPELLS),
                     'Spell 3': Obj.get_flag(args[3], SPELLS),
                 }
-            case "WAND" | "STAFF":
+            case "WAND" | "STAFF" | "INSTRUMENT":
                 results = {
                     'Level': args[0],
                     'Max_Charges': args[1],

--- a/src/act.informative.cpp
+++ b/src/act.informative.cpp
@@ -1545,6 +1545,7 @@ void identify_obj(ObjData *obj, CharData *ch, int location) {
         break;
     case ITEM_WAND:
     case ITEM_STAFF:
+    case ITEM_INSTRUMENT:
         char_printf(ch,
                     "This {} casts: {}\n"
                     "It has {} maximum charge{} and {} remaining.\n",

--- a/src/act.item.cpp
+++ b/src/act.item.cpp
@@ -1451,7 +1451,7 @@ ACMD(do_grab) {
             perform_wear(ch, obj, WEAR_HOLD, false);
         else {
             if (!CAN_WEAR(obj, ITEM_WEAR_HOLD) && GET_OBJ_TYPE(obj) != ITEM_WAND && GET_OBJ_TYPE(obj) != ITEM_STAFF &&
-                GET_OBJ_TYPE(obj) != ITEM_SCROLL && GET_OBJ_TYPE(obj) != ITEM_POTION)
+                GET_OBJ_TYPE(obj) != ITEM_SCROLL && GET_OBJ_TYPE(obj) != ITEM_POTION && GET_OBJ_TYPE(obj) != ITEM_INSTRUMENT)
                 char_printf(ch, "You can't hold that.\n");
             else {
                 perform_wear(ch, obj, WEAR_HOLD, false);
@@ -1780,6 +1780,7 @@ ACMD(do_compare) {
             break;
         case ITEM_WAND:
         case ITEM_STAFF:
+        case ITEM_INSTRUMENT:
             if (!EFF_FLAGGED(ch, EFF_DETECT_MAGIC))
                 char_printf(ch, "You can't tell anything about either item.\n");
             else if (GET_OBJ_VAL(obj1, VAL_WAND_CHARGES_LEFT) == GET_OBJ_VAL(obj2, VAL_WAND_CHARGES_LEFT))

--- a/src/act.other.cpp
+++ b/src/act.other.cpp
@@ -1947,6 +1947,7 @@ ACMD(do_use) {
             }
             break;
         case SCMD_USE:
+        case SCMD_PLAY:
             /* Item isn't in first hand, now check the second. */
             mag_item = GET_EQ(ch, WEAR_HOLD2);
             if (!mag_item || !isname(arg, mag_item->name)) {
@@ -1981,6 +1982,12 @@ ACMD(do_use) {
     case SCMD_USE:
         if ((GET_OBJ_TYPE(mag_item) != ITEM_WAND) && (GET_OBJ_TYPE(mag_item) != ITEM_STAFF)) {
             char_printf(ch, "You can't seem to figure out how to use it.\n");
+            return;
+        }
+        break;
+    case SCMD_PLAY:
+        if (GET_OBJ_TYPE(mag_item) != ITEM_INSTRUMENT) {
+            char_printf(ch, "You can't seem to figure out how to make sound with it.\n");
             return;
         }
         break;

--- a/src/act.wizinfo.cpp
+++ b/src/act.wizinfo.cpp
@@ -391,6 +391,7 @@ void do_stat_object(CharData *ch, ObjData *j) {
         break;
     case ITEM_WAND:
     case ITEM_STAFF:
+    case ITEM_INSTRUMENT:
         resp += fmt::format("Spell: {} at level {}, {} (of {}) charges remaining\n",
                             skill_name(GET_OBJ_VAL(j, VAL_WAND_SPELL)), GET_OBJ_VAL(j, VAL_WAND_LEVEL),
                             GET_OBJ_VAL(j, VAL_WAND_CHARGES_LEFT), GET_OBJ_VAL(j, VAL_WAND_MAX_CHARGES));

--- a/src/ai_utils.cpp
+++ b/src/ai_utils.cpp
@@ -291,8 +291,9 @@ int appraise_item(CharData *ch, ObjData *obj) {
         break;
     case ITEM_WAND:
     case ITEM_STAFF:
+    case ITEM_INSTRUMENT:
         value = value_spell(GET_OBJ_VAL(obj, VAL_WAND_SPELL), true) * GET_OBJ_VAL(obj, VAL_WAND_CHARGES_LEFT);
-        if (GET_OBJ_TYPE(obj) == ITEM_STAFF)
+        if (GET_OBJ_TYPE(obj) == ITEM_STAFF || GET_OBJ_TYPE(obj) == ITEM_INSTRUMENT)
             value *= 3;
         value += GET_OBJ_VAL(obj, VAL_WAND_LEVEL);
         /* charges total (value 1) doesn't matter right now */

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -1739,6 +1739,7 @@ void init_obj_proto(ObjData *obj) {
             verify_obj_spell(obj, VAL_WAND_SPELL, false);
             break;
         case ITEM_STAFF:
+        case ITEM_INSTRUMENT:
             verify_obj_spell(obj, VAL_STAFF_SPELL, false);
             break;
         case ITEM_POTION:

--- a/src/dg_scripts.cpp
+++ b/src/dg_scripts.cpp
@@ -36,7 +36,7 @@ const char *trig_types[] = {"Global",    "Random", "Command", "Speech", "Act",  
 
 /* obj trigger types */
 const char *otrig_types[] = {"Global", "Random", "Command", "Attack", "Defense", "Timer",  "Get",
-                             "Drop",   "Give",   "Wear",    "Death",  "Remove",  "Look", "UNUSED",
+                             "Drop",   "Give",   "Wear",    "Death",  "Remove",  "Look",   "Use",
                              "Load",   "Cast",   "Leave",   "UNUSED", "Consume", "Time",   "\n"};
 
 /* wld trigger types */

--- a/src/dg_triggers.cpp
+++ b/src/dg_triggers.cpp
@@ -986,6 +986,36 @@ int look_otrigger(ObjData *obj, CharData *actor, char *name, const char *additio
     return ret_val;
 }
 
+int use_otrigger(ObjData *obj, ObjData *tobj, CharData *actor, CharData *victim) {
+    TrigData *t;
+    char buf[MAX_INPUT_LENGTH];
+    int ret_val = 1;
+
+
+    if (!char_susceptible_to_triggers(actor) || !SCRIPT_CHECK(obj, OTRIG_USE))
+        return ret_val;
+
+    if (victim && (victim != actor)) {
+        if (!char_susceptible_to_triggers(victim))
+            return ret_val;
+    }
+
+    for (t = TRIGGERS(SCRIPT(obj)); t; t = t->next) {
+        if (TRIGGER_CHECK(t, OTRIG_USE) && (random_number(1, 100) <= GET_TRIG_NARG(t))) {
+            ADD_UID_VAR(buf, t, actor, "actor");
+            if (tobj && (obj != tobj))
+                ADD_UID_VAR(buf, t, tobj, "object");
+            if (victim && (victim != actor))
+                ADD_UID_VAR(buf, t, victim, "victim");
+            ret_val = (script_driver(&obj, t, OBJ_TRIGGER, TRIG_NEW) && obj);
+            if (!ret_val)
+                return ret_val;
+        }
+    }
+
+    return ret_val;
+}
+
 /*
  *  world triggers
  */

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -692,6 +692,7 @@ const CommandInfo cmd_info[] = {
     {"petition", POS_PRONE, STANCE_DEAD, do_petition, 0, 0, CMD_ANY},
     {"pfilemaint", POS_PRONE, STANCE_DEAD, do_pfilemaint, LVL_OVERLORD, 0, 0},
     {"pick", POS_STANDING, STANCE_ALERT, do_gen_door, 1, SCMD_PICK, CMD_HIDE | CMD_NOFIGHT},
+    {"play", POS_SITTING, STANCE_RESTING, do_use, 1, SCMD_PLAY, 0},
     {"players", POS_PRONE, STANCE_DEAD, do_players, LVL_HEAD_C, 0, CMD_ANY},
     {"point", POS_PRONE, STANCE_RESTING, do_point, 0, 0, 0},
     {"poke", POS_PRONE, STANCE_RESTING, do_action, 0, 0, 0},

--- a/src/objects.cpp
+++ b/src/objects.cpp
@@ -59,6 +59,7 @@ static int min_value(ObjData *obj, int val) {
     switch (GET_OBJ_TYPE(obj)) {
     case ITEM_WAND:
     case ITEM_STAFF:
+    case ITEM_INSTRUMENT:
         if (val == VAL_WAND_MAX_CHARGES)
             min = std::max(min, GET_OBJ_VAL(obj, VAL_WAND_CHARGES_LEFT));
         break;
@@ -94,6 +95,7 @@ static int max_value(ObjData *obj, int val) {
         break;
     case ITEM_WAND:
     case ITEM_STAFF:
+    case ITEM_INSTRUMENT:
         if (val == VAL_WAND_CHARGES_LEFT)
             max = std::min(max, GET_OBJ_VAL(obj, VAL_WAND_MAX_CHARGES));
         break;

--- a/src/oedit.cpp
+++ b/src/oedit.cpp
@@ -803,6 +803,7 @@ void oedit_disp_val1_menu(DescriptorData *d) {
     case ITEM_WAND:
     case ITEM_STAFF:
     case ITEM_POTION:
+    case ITEM_INSTRUMENT:
         char_printf(d->character, "Spell level:\n");
         break;
     case ITEM_WEAPON:
@@ -859,6 +860,7 @@ void oedit_disp_val2_menu(DescriptorData *d) {
         break;
     case ITEM_WAND:
     case ITEM_STAFF:
+    case ITEM_INSTRUMENT:
         char_printf(d->character, "Max number of charges:\n");
         break;
     case ITEM_WEAPON:
@@ -907,6 +909,7 @@ void oedit_disp_val3_menu(DescriptorData *d) {
         break;
     case ITEM_WAND:
     case ITEM_STAFF:
+    case ITEM_INSTRUMENT:
         char_printf(d->character, "Number of charges remaining:\n");
         break;
     case ITEM_WEAPON:
@@ -945,6 +948,7 @@ void oedit_disp_val4_menu(DescriptorData *d) {
     case ITEM_POTION:
     case ITEM_WAND:
     case ITEM_STAFF:
+    case ITEM_INSTRUMENT:
         oedit_disp_spells_menu(d);
         break;
     case ITEM_WEAPON:
@@ -1076,6 +1080,7 @@ void oedit_disp_obj_values(DescriptorData *d) {
         break;
     case ITEM_WAND:
     case ITEM_STAFF:
+    case ITEM_INSTRUMENT:
         sprintf(buf,
                 "         Spell : %s%s%s\n"
                 "   Spell Level : %s%d%s\n"
@@ -1544,6 +1549,7 @@ void oedit_parse(DescriptorData *d, char *arg) {
         case ITEM_POTION:
         case ITEM_WAND:
         case ITEM_STAFF:
+        case ITEM_INSTRUMENT:
             GET_OBJ_VAL(OLC_OBJ(d), 3) = number;
             if (number < 0 || number > MAX_SPELLS || !strcasecmp(skills[number].name, "!UNUSED!")) {
                 oedit_disp_val4_menu(d);

--- a/src/shop.cpp
+++ b/src/shop.cpp
@@ -242,7 +242,7 @@ int trade_with(ObjData *item, int shop_nr) {
     for (counter = 0; SHOP_BUYTYPE(shop_nr, counter) != NOTHING; counter++)
         if (SHOP_BUYTYPE(shop_nr, counter) == GET_OBJ_TYPE(item)) {
             if ((GET_OBJ_VAL(item, VAL_WAND_CHARGES_LEFT) == 0) &&
-                ((GET_OBJ_TYPE(item) == ITEM_WAND) || (GET_OBJ_TYPE(item) == ITEM_STAFF)))
+                ((GET_OBJ_TYPE(item) == ITEM_WAND) || (GET_OBJ_TYPE(item) == ITEM_STAFF) || (GET_OBJ_TYPE(item) == ITEM_INSTRUMENT)))
                 return OBJECT_DEAD;
             else if (evaluate_expression(item, SHOP_BUYWORD(shop_nr, counter)))
                 return OBJECT_OK;
@@ -932,7 +932,7 @@ std::string list_object(CharData *keeper, ObjData *obj, CharData *ch, int cnt, i
         buf += fmt::format(" of {}", LIQ_NAME(GET_OBJ_VAL(obj, VAL_DRINKCON_LIQUID)));
     if (!shop_producing(obj, shop_nr))
         buf += fmt::format(" (x{:2d})", cnt);
-    if ((GET_OBJ_TYPE(obj) == ITEM_WAND) || (GET_OBJ_TYPE(obj) == ITEM_STAFF))
+    if ((GET_OBJ_TYPE(obj) == ITEM_WAND) || (GET_OBJ_TYPE(obj) == ITEM_STAFF) || (GET_OBJ_TYPE(obj) == ITEM_INSTRUMENT))
         if (GET_OBJ_VAL(obj, VAL_WAND_CHARGES_LEFT) < GET_OBJ_VAL(obj, VAL_WAND_MAX_CHARGES))
             buf += " (partially used)";
 

--- a/src/vsearch.cpp
+++ b/src/vsearch.cpp
@@ -1110,9 +1110,9 @@ const struct VSearchType vsearch_object_modes[] = {
     {17, "effflags", FLAGS, effect_flags},
     {18, "triggervnum", INTEGER},
     {19, "lasts", INTEGER},            /* light */
-    {20, "casts", SPLNAME},            /* wand, staff, potion, scroll */
-    {21, "chargesinitial", INTEGER},   /* staff, wand */
-    {22, "chargesremaining", INTEGER}, /* staff, wand */
+    {20, "casts", SPLNAME},            /* wand, staff, potion, scroll, instrument */
+    {21, "chargesinitial", INTEGER},   /* staff, wand, instrument */
+    {22, "chargesremaining", INTEGER}, /* staff, wand, instrument */
     {23, "damnodice", INTEGER},        /* weapon */
     {24, "damsizedice", INTEGER},      /* weapon */
     {25, "attacktype", STRING},        /* weapon */
@@ -1139,15 +1139,15 @@ const struct VSearchType vsearch_object_modes[] = {
     {0, nullptr, 0},
 };
 
-#define MAX_SEARCH_ITEM_TYPES 4
+#define MAX_SEARCH_ITEM_TYPES 5
 const struct vsearch_object_value_type {
     int type;
     int item_types[MAX_SEARCH_ITEM_TYPES];
 } value_types[] = {
     {19, {ITEM_LIGHT}},                                      /* lasts */
-    {20, {ITEM_WAND, ITEM_STAFF, ITEM_POTION, ITEM_SCROLL}}, /* casts */
-    {21, {ITEM_WAND, ITEM_STAFF}},                           /* chargesinitial */
-    {22, {ITEM_WAND, ITEM_STAFF}},                           /* chargesremaining */
+    {20, {ITEM_WAND, ITEM_STAFF, ITEM_POTION, ITEM_SCROLL, ITEM_INSTRUMENT}}, /* casts */
+    {21, {ITEM_WAND, ITEM_STAFF, ITEM_INSTRUMENT}},                           /* chargesinitial */
+    {22, {ITEM_WAND, ITEM_STAFF, ITEM_INSTRUMENT}},                           /* chargesremaining */
     {23, {ITEM_WEAPON}},                                     /* damnodice */
     {24, {ITEM_WEAPON}},                                     /* damsizedice */
     {25, {ITEM_WEAPON}},                                     /* attacktype */
@@ -1240,6 +1240,7 @@ ACMD(do_osearch) {
             break;
         case ITEM_WAND:
         case ITEM_STAFF:
+        case ITEM_INSTRUMENT:
             header_type = "Charges Left/Total, Spell";
             break;
         case ITEM_WEAPON:
@@ -1387,7 +1388,7 @@ ACMD(do_osearch) {
             match = numeric_compare(GET_OBJ_VAL(obj, 3), value, bound, compare);
             break;
         case 20:
-            if (GET_OBJ_TYPE(obj) == ITEM_STAFF || GET_OBJ_TYPE(obj) == ITEM_WAND)
+            if (GET_OBJ_TYPE(obj) == ITEM_STAFF || GET_OBJ_TYPE(obj) == ITEM_WAND || GET_OBJ_TYPE(obj) == ITEM_INSTRUMENT)
                 match = (GET_OBJ_VAL(obj, VAL_STAFF_SPELL) == value);
             else if (GET_OBJ_TYPE(obj) == ITEM_SCROLL || GET_OBJ_TYPE(obj) == ITEM_POTION)
                 match =
@@ -1476,6 +1477,7 @@ ACMD(do_osearch) {
                     break;
                 case ITEM_WAND:
                 case ITEM_STAFF:
+                case ITEM_INSTRUMENT:
                     vbuf += fmt::format("{:2d}/{:2d} {}{}{}", GET_OBJ_VAL(obj, VAL_WAND_CHARGES_LEFT),
                                         GET_OBJ_VAL(obj, VAL_WAND_MAX_CHARGES), cyn,
                                         skill_name(GET_OBJ_VAL(obj, VAL_WAND_SPELL)), nrm);


### PR DESCRIPTION
The "instrument" magic item is just a staff, but re-orders the action desc display flow so the action desc text is displayed to both the user and the room when it's used.  Allows for flavor text around the kind of music the instrument plays.

The "use" trigger is checked when magic items are activated.  This supplements "command" triggers by allowing us to make sure specific items are being activated (ie 3.wand).  This will be immediately used in Meteorswarm and Charm Person.  The trigger can block the use of the magic item as well.

It will also allow us to create new scrolls of recall without having to create specprocs for them, and allows us to more quickly change where players are sent when they're activated.