### PR TITLE
Grant berserker rescue, guard, lower berserk threshold

### DIFF
--- a/include/defines.hpp
+++ b/include/defines.hpp
@@ -222,7 +222,7 @@
 
 /* Levels of rage */
 #define RAGE_NONE 0
-#define RAGE_ANNOYED 250
+#define RAGE_ANNOYED 100
 #define RAGE_ANGRY 500
 #define RAGE_IRATE 750
 #define RAGE_CRAZED 1000

--- a/src/act.offensive.cpp
+++ b/src/act.offensive.cpp
@@ -1263,6 +1263,11 @@ ACMD(do_rescue) {
         return;
     }
 
+    if (GET_SKILL(ch, SKILL_BERSERK) && !EFF_FLAGGED(ch, EFF_BERSERK)) {
+        act("You aren't angry enough to rescue $M!", false, ch, 0, vict, TO_CHAR);
+        return;
+    }
+
     /* Choose a random attacker from those fighting vict */
     attacker = vict->attackers;
     num = 1;
@@ -2426,7 +2431,7 @@ ACMD(do_berserk) {
         return;
     }
 
-    if (GET_RAGE(ch) < RAGE_ANGRY) {
+    if (GET_RAGE(ch) < RAGE_ANNOYED) {
         char_printf(ch, "You're not angry enough yet!\n");
         return;
     }

--- a/src/class.cpp
+++ b/src/class.cpp
@@ -1736,6 +1736,7 @@ void assign_class_skills(void) {
 
     chant_assign(CHANT_SPIRIT_WOLF, CLASS_BERSERKER, 25);
     chant_assign(CHANT_SPIRIT_BEAR, CLASS_BERSERKER, 60);
+    chant_assign(CHANT_APOCALYPTIC_ANTHEM, CLASS_BERSERKER, 75);
     chant_assign(CHANT_INTERMINABLE_WRATH, CLASS_BERSERKER, 90);
 
     /* CLERIC */

--- a/src/class.cpp
+++ b/src/class.cpp
@@ -1724,7 +1724,9 @@ void assign_class_skills(void) {
     skill_assign(SKILL_PARRY, CLASS_BERSERKER, 15);
     skill_assign(SKILL_DUAL_WIELD, CLASS_BERSERKER, 20);
     skill_assign(SKILL_CHANT, CLASS_BERSERKER, 25);
+    skill_assign(SKILL_GUARD, CLASS_BERSERKER, 25);
     skill_assign(SKILL_BATTLE_HOWL, CLASS_BERSERKER, 30);
+    skill_assign(SKILL_RESCUE, CLASS_BERSERKER, 35);
     skill_assign(SKILL_TANTRUM, CLASS_BERSERKER, 45);
     skill_assign(SKILL_MEDITATE, CLASS_BERSERKER, 50);
     skill_assign(SKILL_RIPOSTE, CLASS_BERSERKER, 50);

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -169,15 +169,38 @@ CharData *check_guard(CharData *ch, CharData *victim, int gag_output) {
         attack_ok(ch, victim->guarded_by, false)) {
         improve_skill(victim->guarded_by, SKILL_GUARD);
         if (GET_ISKILL(victim->guarded_by, SKILL_GUARD) > random_number(1, 1100)) {
-            if (!gag_output) {
-                act("$n jumps in front of $N, shielding $M from the assault.", false, victim->guarded_by, 0, victim,
-                    TO_NOTVICT);
-                act("$n jumps in front of you, shielding you from the assault.", false, victim->guarded_by, 0, victim,
-                    TO_VICT);
-                act("You jump in front of $N, shielding $M from the assault.", false, victim->guarded_by, 0, victim,
-                    TO_CHAR);
+            if (GET_ISKILL(victim->guarded_by, SKILL_BERSERK)) {
+                if (EFF_FLAGGED(victim->guarded_by, EFF_BERSERK)) {
+                    if (!gag_output) {
+                        act("$n jumps in front of $N, shielding $M from the assault.", false, victim->guarded_by, 0, victim,
+                            TO_NOTVICT);
+                        act("$n jumps in front of you, shielding you from the assault.", false, victim->guarded_by, 0, victim,
+                            TO_VICT);
+                        act("You jump in front of $N, shielding $M from the assault.", false, victim->guarded_by, 0, victim,
+                            TO_CHAR);
+                    }
+                    return victim->guarded_by;
+                } else {
+                    if (!gag_output) {
+                        act("$n looks to intercept the attack on $N, but isn't angry enough.", false, victim->guarded_by, 0, victim,
+                            TO_NOTVICT);
+                        act("$n looks to shield you from the attack, but isn't angry enough.", false, victim->guarded_by, 0, victim,
+                            TO_VICT);
+                        act("You look to shield $N, but aren't angry enough.", false, victim->guarded_by, 0, victim,
+                            TO_CHAR);
+                    }
+                }
+            } else {
+                if (!gag_output) {
+                    act("$n jumps in front of $N, shielding $M from the assault.", false, victim->guarded_by, 0, victim,
+                        TO_NOTVICT);
+                    act("$n jumps in front of you, shielding you from the assault.", false, victim->guarded_by, 0, victim,
+                        TO_VICT);
+                    act("You jump in front of $N, shielding $M from the assault.", false, victim->guarded_by, 0, victim,
+                        TO_CHAR);
+                }
+                return victim->guarded_by;
             }
-            return victim->guarded_by;
         } else if (!gag_output) {
             act("$n tries to intercept the attack on $N, but isn't quick enough.", false, victim->guarded_by, 0, victim,
                 TO_NOTVICT);


### PR DESCRIPTION
- Allows Berserkers to rescue and guard, but only while berserking
  - A target can be designated as guarded at any time, but guard will only intercept while berserking
- Lowered threshold to activate berserk from 500 to 100
- Added Apocalyptic Anthem to list of chants for aggro control