### PR TITLE
displays damage types on weapons and indicated triggers

### DIFF
--- a/src/act.informative.cpp
+++ b/src/act.informative.cpp
@@ -1560,7 +1560,7 @@ void identify_obj(ObjData *obj, CharData *ch, int location) {
                     "Damage Dice is '{}D{}' "
                     "for an average per-round damage of {:.1f}.\n"
                     "Damage Type is {}.\n",
-                    GET_OBJ_VAL(obj, VAL_WEAPON_DICE_NUM), GET_OBJ_VAL(obj, VAL_WEAPON_DICE_SIZE), WEAPON_AVERAGE(obj), GET_OBJ_VAL(obj, VAL_WEAPON_DAM_TYPE));
+                    GET_OBJ_VAL(obj, VAL_WEAPON_DICE_NUM), GET_OBJ_VAL(obj, VAL_WEAPON_DICE_SIZE), WEAPON_AVERAGE(obj), attack_hit_text[GET_OBJ_VAL(obj, VAL_WEAPON_DAM_TYPE)].singular);
         break;
     case ITEM_ARMOR:
     case ITEM_TREASURE:
@@ -1590,6 +1590,10 @@ void identify_obj(ObjData *obj, CharData *ch, int location) {
     for (i = 0; i < MAX_OBJ_APPLIES; i++)
         if (obj->applies[i].location != APPLY_NONE)
             char_printf(ch, "   Apply: {}\n", format_apply(obj->applies[i].location, obj->applies[i].modifier));
+
+    if (SCRIPT(obj) || (GET_OBJ_RNUM(obj) >= 0 && obj_index[GET_OBJ_RNUM(obj)].func)) {
+        char_printf(ch, "   You sense this item has hidden special properties!\n");
+    }
 
 }
 


### PR DESCRIPTION
Two changes to Identify:
- Properly displays the damage type by name, rather than index number
- As weapons could have multiple damage types now, I revised the old code to indicate if an item has a trigger or specproc without specifying what it is.  Players will now simply see "This item has hidden special properties!" if it has either a trigger or a specproc.