### PR TITLE
Increase poison lethality

### DIFF
--- a/include/limits.hpp
+++ b/include/limits.hpp
@@ -26,3 +26,4 @@ void check_idling(CharData *ch);
 void point_update(void);
 void start_decomposing(ObjData *obj);
 void stop_decomposing(ObjData *obj);
+void sick_update(void);

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -138,6 +138,7 @@ void boot_world(void);
 void zone_update(void);
 void effect_update(void); /* In spells.c */
 void point_update(void);  /* In limits.c */
+void sick_update(void); /* In limits.c */
 void mobile_activity(void);
 void mobile_spec_activity(void);
 void string_add(DescriptorData *d, char *str);
@@ -970,6 +971,11 @@ void heartbeat(int pulse) {
     if (!(pulse % PASSES_PER_SEC)) {
         if (reboot_auto)
             check_auto_rebooting();
+    }
+
+    if (!(pulse % (PULSE_VIOLENCE * 6))) {
+        /* Check poison and disease every 6 rounds. */
+        sick_update();
     }
 
     if (!(pulse % (SECS_PER_MUD_HOUR * PASSES_PER_SEC))) {

--- a/src/limits.cpp
+++ b/src/limits.cpp
@@ -554,6 +554,24 @@ void decay_object(ObjData *obj) {
     extract_obj(obj);
 }
 
+/* Proc poison */
+
+void sick_update(void) {
+    CharData *i, *next_char;
+    ObjData *j;
+
+    /* characters */
+    for (i = character_list; i; i = next_char) {
+        next_char = i->next;
+
+        if (GET_STANCE(i) >= STANCE_STUNNED) {
+            /* Do damage with a maximum of 5.9% of HP minus 2x con bonus hp for PCs and 2% for NPCs */
+            if (EFF_FLAGGED(i, EFF_POISON))
+                damage(i, i, IS_NPC(i) ? (GET_MAX_HIT(i) / 50) : ((GET_MAX_HIT(i) / 17) - (con_app[GET_CON(i)].hitp) * 2), SPELL_POISON);
+        }
+    }
+}
+
 /* Update PCs, NPCs, and objects */
 void point_update(void) {
     CharData *i, *next_char;
@@ -564,8 +582,6 @@ void point_update(void) {
         next_char = i->next;
 
         if (GET_STANCE(i) >= STANCE_STUNNED) {
-            if (EFF_FLAGGED(i, EFF_POISON))
-                damage(i, i, GET_LEVEL(i) / 2, SPELL_POISON);
             if (GET_STANCE(i) == STANCE_DEAD)
                 continue;
             /* Do damage with a maximum of 5% of HP for PCs and 2% for NPCs,

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2499,7 +2499,7 @@ int mag_affect(int skill, CharData *ch, CharData *victim, int spellnum, int save
         eff[0].location = APPLY_STR;
         eff[0].modifier = (-2 - (skill / 4) - (skill / 20)) * susceptibility(victim, DAM_POISON) / 100; /* max -32 */
         SET_FLAG(eff[0].flags, EFF_POISON);
-        eff[0].duration = 4 + (skill / 10); /* max 14 */
+        eff[0].duration = 2 + (skill / 25) + (wis_app[GET_WIS(ch)].bonus / 2); /* min 2, max 7 */
         eff[0].type = SPELL_POISON;
         to_vict = "You feel very sick.";
         to_room = "$N gets violently ill!";

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2499,7 +2499,7 @@ int mag_affect(int skill, CharData *ch, CharData *victim, int spellnum, int save
         eff[0].location = APPLY_STR;
         eff[0].modifier = (-2 - (skill / 4) - (skill / 20)) * susceptibility(victim, DAM_POISON) / 100; /* max -32 */
         SET_FLAG(eff[0].flags, EFF_POISON);
-        eff[0].duration = 2 + (skill / 25) + (wis_app[GET_WIS(ch)].bonus / 2); /* min 2, max 7 */
+        eff[0].duration = 2 + (skill / 33) + (wis_app[GET_WIS(ch)].bonus / 2); /* min 2, max 8 */
         eff[0].type = SPELL_POISON;
         to_vict = "You feel very sick.";
         to_room = "$N gets violently ill!";


### PR DESCRIPTION
- Moves the check for eff_poison from point_update to a new function sick_update
- Disease will be moved into this function in a future pass
- sick_update checks every 6 rounds
- Poison now deals 2% of max HP in damage to NPCs but 5.88% minus Con bonus HP to PCs
- Duration reduced from (4 + 10% of skill) [min 4, max 14] to (2 + 3% of skill + 1/2 Wis Mod) [min 2, max 8]