### PR TITLE
correctly sets default damage type when backstabbing to null instead of junk number

### DIFF
--- a/src/damage.cpp
+++ b/src/damage.cpp
@@ -53,7 +53,7 @@ int parse_damtype(CharData *ch, char *arg) {
  * probable. */
 
 bool damage_evasion(CharData *ch, CharData *attacker, ObjData *weapon, int dtype) {
-    int s;
+    int s = 0;
 
     /* Ether mobs are not immune at all to blessed physical attacks. */
     if (attacker &&


### PR DESCRIPTION
Prevents a bug that causes mobs to composition evade backstabs from energy weapons.