### PR TITLE
Attempts to stop illusions from attacking their masters

### DIFF
--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -2359,7 +2359,7 @@ void perform_violence(void) {
 
             /* Find the player fighting this NPC who has the lowest hp in the room */
             for (tch = world[IN_ROOM(ch)].people; tch; tch = tch->next_in_room)
-                if (FIGHTING(tch) == ch && !IS_NPC(tch) && CAN_SEE(ch, tch))
+                if (FIGHTING(tch) == ch && !IS_NPC(tch) && CAN_SEE(ch, tch) && tch != ch->master)
                     if (victim == nullptr || GET_HIT(tch) < GET_HIT(victim))
                         victim = tch;
 

--- a/src/mobact.cpp
+++ b/src/mobact.cpp
@@ -279,7 +279,7 @@ void mobile_spec_activity(void) {
 
         /* Look for people I'd like to attack */
         if (!ROOM_FLAGGED(ch->in_room, ROOM_PEACEFUL) && !EFF_FLAGGED(ch, EFF_MESMERIZED) &&
-            (!EFF_FLAGGED(ch, EFF_CHARM) || (ch->master && ch->master->in_room != ch->in_room))) {
+           (!EFF_FLAGGED(ch, EFF_CHARM) || (ch->master && ch->master->in_room != ch->in_room))) {
             if ((vict = find_aggr_target(ch))) {
                 mob_attack(ch, vict);
                 continue;
@@ -439,6 +439,9 @@ void mob_attack(CharData *ch, CharData *victim) {
     /* Mesmerized or paralyzed mobs should not attack.
      * Mob memory attack seems to be by-passing attack_ok check */
     if (EFF_FLAGGED(ch, EFF_MESMERIZED) || EFF_FLAGGED(ch, EFF_MINOR_PARALYSIS) || EFF_FLAGGED(ch, EFF_MAJOR_PARALYSIS))
+        return;
+
+    if (victim == ch->master)
         return;
 
     /* Mob should not execute any special mobile AI procedures. */


### PR DESCRIPTION
This is an attempt to fix a bug Zaver is having where his illusions are switching to him when using the kick command.

I haven't been able to reproduce, but he's showed me multiple logs where it happens.  From everything I can tell, this should prevent it from happening, though I don't know what the actual cause is because again, I can't reproduce it myself.