### PR TITLE
"ASLEEP" flag for triggers

### DIFF
--- a/src/dg_scripts.cpp
+++ b/src/dg_scripts.cpp
@@ -2360,10 +2360,8 @@ int script_driver(void *go_address, TrigData *trig, int type, int mode) {
 
         if (type == MOB_TRIGGER && !(trig->trigger_type & MTRIG_DEATH)) { /* only death trigs are immune to all tests */
             if (!AWAKE((CharData *)go)) {
-                depth--;
-                if (mode == TRIG_NEW)
-                    GET_TRIG_DEPTH(trig) = 0; /* reset trigger totally if instant bail */
-                return 0;
+                /* abort execution and clean up */
+                break;
             }
 
             if (CASTING((CharData *)go)) {

--- a/src/dg_scripts.cpp
+++ b/src/dg_scripts.cpp
@@ -33,17 +33,20 @@
 /* mob trigger types */
 const char *trig_types[] = {"Global",    "Random", "Command", "Speech", "Act",      "Death", "Greet",
                             "Greet-All", "Entry",  "Receive", "Fight",  "HitPrcnt", "Bribe", "SpeechTo*",
-                            "Load",      "Cast",   "Leave",   "Door",   "Look",     "Time",  "\n"};
+                            "Load",      "Cast",   "Leave",   "Door",   "Look",     "Time",  "Asleep",
+                            "\n"};
 
 /* obj trigger types */
 const char *otrig_types[] = {"Global", "Random", "Command", "Attack", "Defense", "Timer", "Get",
                              "Drop",   "Give",   "Wear",    "Death",  "Remove",  "Look",  "Use",
-                             "Load",   "Cast",   "Leave",   "UNUSED", "Consume", "Time",  "\n"};
+                             "Load",   "Cast",   "Leave",   "UNUSED", "Consume", "Time",  "UNUSED",
+                             "\n"};
 
 /* wld trigger types */
 const char *wtrig_types[] = {"Global", "Random",    "Command", "Speech", "UNUSED", "Reset",  "Preentry",
                              "Drop",   "Postentry", "UNUSED",  "UNUSED", "UNUSED", "UNUSED", "UNUSED",
-                             "UNUSED", "Cast",      "Leave",   "Door",   "UNUSED", "Time",   "\n"};
+                             "UNUSED", "Cast",      "Leave",   "Door",   "UNUSED", "Time",   "UNUSED",
+                             "\n"};
 
 TrigData *trigger_list = nullptr; /* all attached triggers */
 
@@ -2359,7 +2362,7 @@ int script_driver(void *go_address, TrigData *trig, int type, int mode) {
             break;
 
         if (type == MOB_TRIGGER && !(trig->trigger_type & MTRIG_DEATH)) { /* only death trigs are immune to all tests */
-            if (!AWAKE((CharData *)go)) {
+            if (!check_awake(trig, (CharData *)go)) {
                 /* abort execution and clean up */
                 break;
             }

--- a/src/dg_scripts.hpp
+++ b/src/dg_scripts.hpp
@@ -24,7 +24,7 @@
 
 #define DG_NO_TRIG (1u << 6u) /* don't check act trigger   */
 
-#define NUM_TRIG_TYPE_FLAGS 20
+#define NUM_TRIG_TYPE_FLAGS 21
 
 /* mob trigger types */
 #define MTRIG_GLOBAL (1u << 0u)    /* check even if zone empty   */
@@ -47,6 +47,7 @@
 #define MTRIG_DOOR (1u << 17u)     /* door manipulated in room   */
 #define MTRIG_LOOK (1u << 18u)     /* the mob is looked at       */
 #define MTRIG_TIME (1u << 19u)     /* trigger based on game hour */
+#define MTRIG_ASLEEP (1u << 20u)   /* allow trigger while asleep */
 
 /* obj trigger types */
 #define OTRIG_GLOBAL (1u << 0u)   /* unused                     */
@@ -210,6 +211,8 @@ void reset_wtrigger(RoomData *room);
 void random_mtrigger(CharData *ch);
 void random_otrigger(ObjData *obj);
 void random_wtrigger(RoomData *ch);
+
+bool check_awake(const TrigData* trig, const CharData* ch);
 
 /* function prototypes from scripts.c */
 void script_trigger_check(void);


### PR DESCRIPTION
This PR adds a new flag for mobile triggers that can be used to override the default check to ensure that the mob is awake.

The script will have to deal with the consequences of the mob being asleep -- `ASLEEP` triggers don't give the mob any ability to do stuff they couldn't do otherwise.