### PR TITLE
Improve target string handling

### DIFF
--- a/src/commands/command_context.cpp
+++ b/src/commands/command_context.cpp
@@ -63,6 +63,7 @@ namespace {
  */
 struct TargetSpec {
     std::string keyword;
+    std::set<std::string> keywords;
     int match_index = 1;
     bool match_all = false;
 
@@ -94,6 +95,8 @@ struct TargetSpec {
         } else {
             spec.keyword = std::string{name};
         }
+
+        spec.keywords = EntityUtils::parse_target_string(spec.keyword);
 
         return spec;
     }
@@ -283,7 +286,7 @@ std::shared_ptr<Actor> CommandContext::find_actor_target(std::string_view name) 
         if (!room_actor->is_visible_to(*actor))
             continue;
 
-        if (room_actor->matches_target_string(spec.keyword)) {
+        if (room_actor->matches_all_keywords(spec.keywords)) {
             current_match++;
             if (current_match == spec.match_index) {
                 return room_actor;
@@ -311,7 +314,7 @@ std::shared_ptr<Actor> CommandContext::find_actor_global(std::string_view name) 
             if (!online_actor || online_actor == actor)
                 continue; // Skip self
 
-            if (online_actor->matches_target_string(spec.keyword)) {
+            if (online_actor->matches_all_keywords(spec.keywords)) {
                 current_match++;
                 if (current_match == spec.match_index) {
                     return online_actor;
@@ -342,7 +345,7 @@ std::shared_ptr<Object> CommandContext::find_object_target(std::string_view name
         if (!obj)
             continue;
 
-        if (obj->matches_target_string(spec.keyword)) {
+        if (obj->matches_all_keywords(spec.keywords)) {
             current_match++;
             if (current_match == spec.match_index) {
                 return obj;
@@ -356,7 +359,7 @@ std::shared_ptr<Object> CommandContext::find_object_target(std::string_view name
         if (!obj)
             continue;
 
-        if (obj->matches_target_string(spec.keyword)) {
+        if (obj->matches_all_keywords(spec.keywords)) {
             current_match++;
             if (current_match == spec.match_index) {
                 return obj;
@@ -371,7 +374,7 @@ std::shared_ptr<Object> CommandContext::find_object_target(std::string_view name
             if (!obj)
                 continue;
 
-            if (obj->matches_target_string(spec.keyword)) {
+            if (obj->matches_all_keywords(spec.keywords)) {
                 current_match++;
                 if (current_match == spec.match_index) {
                     return obj;
@@ -503,7 +506,7 @@ TargetInfo CommandContext::resolve_target(std::string_view name) const {
     }
 
     // Check if the name matches the current actor (allows "stat samui" to work on yourself)
-    if (actor && actor->matches_keyword_prefix(name)) {
+    if (actor && actor->matches_target_string(name)) {
         TargetInfo info;
         info.type = TargetType::Self;
         info.actor = actor;

--- a/src/commands/economy_commands.cpp
+++ b/src/commands/economy_commands.cpp
@@ -716,7 +716,7 @@ Result<CommandResult> cmd_account(const CommandContext &ctx) {
                 auto obj_proto = world.get_object_prototype(acct_item.object_id);
                 if (obj_proto) {
                     // Check if the object's keywords match
-                    if (obj_proto->matches_keyword(item_arg)) {
+                    if (obj_proto->matches_target_string(item_arg)) {
                         found_item = acct_item;
                         break;
                     }

--- a/src/commands/object_commands.cpp
+++ b/src/commands/object_commands.cpp
@@ -219,7 +219,7 @@ std::shared_ptr<Object> find_drinkable(const CommandContext &ctx,
         }
 
         // Check if it matches by object keyword
-        if (obj->matches_keyword(target_name)) {
+        if (obj->matches_target_string(target_name)) {
             return true;
         }
 
@@ -323,7 +323,7 @@ Result<CommandResult> cmd_get(const CommandContext &ctx) {
         // First check inventory for the object
         std::shared_ptr<Object> potential_container = nullptr;
         for (const auto &obj : inventory_items) {
-            if (obj && obj->matches_keyword(container_name)) {
+            if (obj && obj->matches_target_string(container_name)) {
                 potential_container = obj;
                 if (obj->is_container()) {
                     source_container = obj;
@@ -336,7 +336,7 @@ Result<CommandResult> cmd_get(const CommandContext &ctx) {
         if (!potential_container) {
             auto &room_objects = ctx.room->contents_mutable().objects;
             for (auto &obj : room_objects) {
-                if (obj && obj->matches_keyword(container_name)) {
+                if (obj && obj->matches_target_string(container_name)) {
                     potential_container = obj;
                     if (obj->is_container()) {
                         source_container = obj;
@@ -565,7 +565,7 @@ Result<CommandResult> cmd_get(const CommandContext &ctx) {
 
         // Handle single object get
         for (auto &obj : room_objects) {
-            if (obj && obj->matches_keyword(ctx.arg(0))) {
+            if (obj && obj->matches_target_string(ctx.arg(0))) {
                 target_object = obj;
                 break;
             }
@@ -644,7 +644,7 @@ Result<CommandResult> cmd_drop(const CommandContext &ctx) {
 
     auto inventory_items = ctx.actor->inventory().get_all_items();
 
-    // Handle "drop all" 
+    // Handle "drop all"
     if (ctx.arg(0) == "all") {
         if (inventory_items.empty()) {
             ctx.send("You aren't carrying anything.");
@@ -697,7 +697,7 @@ Result<CommandResult> cmd_drop(const CommandContext &ctx) {
     std::shared_ptr<Object> target_object = nullptr;
 
     for (const auto &obj : inventory_items) {
-        if (obj && obj->matches_keyword(ctx.arg(0))) {
+        if (obj && obj->matches_target_string(ctx.arg(0))) {
             target_object = obj;
             break;
         }
@@ -808,7 +808,7 @@ Result<CommandResult> cmd_put(const CommandContext &ctx) {
         for (const auto &obj : ctx.actor->inventory().get_all_items()) {
             if (!obj)
                 continue;
-            if (obj->matches_keyword(keyword)) {
+            if (obj->matches_target_string(keyword)) {
                 inventory_items_to_put.push_back(obj);
                 if (static_cast<int>(inventory_items_to_put.size()) >= put_count) {
                     break;
@@ -839,7 +839,7 @@ Result<CommandResult> cmd_put(const CommandContext &ctx) {
     // First check inventory
     auto all_inventory = ctx.actor->inventory().get_all_items();
     for (const auto &obj : all_inventory) {
-        if (obj && obj->matches_keyword(container_name)) {
+        if (obj && obj->matches_target_string(container_name)) {
             // Don't use an item we're trying to put as the container
             bool is_item_to_put = false;
             for (const auto &item : inventory_items_to_put) {
@@ -862,7 +862,7 @@ Result<CommandResult> cmd_put(const CommandContext &ctx) {
     if (!potential_container) {
         auto &room_objects = ctx.room->contents_mutable().objects;
         for (auto &obj : room_objects) {
-            if (obj && obj->matches_keyword(container_name)) {
+            if (obj && obj->matches_target_string(container_name)) {
                 potential_container = obj;
                 if (obj->is_container()) {
                     container = obj;
@@ -1103,7 +1103,7 @@ Result<CommandResult> cmd_wear(const CommandContext &ctx) {
     std::shared_ptr<Object> target_object = nullptr;
 
     for (const auto &obj : inventory_items) {
-        if (obj && obj->matches_keyword(ctx.arg(0))) {
+        if (obj && obj->matches_target_string(ctx.arg(0))) {
             target_object = obj;
             break;
         }
@@ -1146,7 +1146,7 @@ Result<CommandResult> cmd_wield(const CommandContext &ctx) {
     std::shared_ptr<Object> target_object = nullptr;
 
     for (const auto &obj : inventory_items) {
-        if (obj && obj->matches_keyword(ctx.arg(0))) {
+        if (obj && obj->matches_target_string(ctx.arg(0))) {
             target_object = obj;
             break;
         }
@@ -1190,7 +1190,7 @@ Result<CommandResult> cmd_remove(const CommandContext &ctx) {
     EntityId target_item_id = INVALID_ENTITY_ID;
 
     for (const auto &obj : equipped_items) {
-        if (obj && obj->matches_keyword(ctx.arg(0))) {
+        if (obj && obj->matches_target_string(ctx.arg(0))) {
             target_object = obj;
             target_item_id = obj->id();
             break;
@@ -1286,21 +1286,21 @@ Result<CommandResult> cmd_open(const CommandContext &ctx) {
 
     // Find container in room or inventory
     std::shared_ptr<Object> target_obj = nullptr;
-    
+
     // First check inventory
     auto inventory_items = ctx.actor->inventory().get_all_items();
     for (const auto &obj : inventory_items) {
-        if (obj && obj->matches_keyword(target_name)) {
+        if (obj && obj->matches_target_string(target_name)) {
             target_obj = obj;
             break;
         }
     }
-    
+
     // If not found in inventory, check room
     if (!target_obj) {
         auto &room_objects = ctx.room->contents_mutable().objects;
         for (auto &obj : room_objects) {
-            if (obj && obj->matches_keyword(target_name)) {
+            if (obj && obj->matches_target_string(target_name)) {
                 target_obj = obj;
                 break;
             }
@@ -1318,17 +1318,17 @@ Result<CommandResult> cmd_open(const CommandContext &ctx) {
     }
 
     auto container_info = target_obj->container_info();
-    
+
     if (!container_info.closeable) {
         ctx.send_error(fmt::format("The {} cannot be opened.", ctx.format_object_name(target_obj)));
         return CommandResult::InvalidTarget;
     }
-    
+
     if (!container_info.closed) {
         ctx.send_error(fmt::format("The {} is already open.", ctx.format_object_name(target_obj)));
         return CommandResult::InvalidState;
     }
-    
+
     if (container_info.locked) {
         ctx.send_error(fmt::format("The {} is locked.", ctx.format_object_name(target_obj)));
         return CommandResult::InvalidState;
@@ -1358,21 +1358,21 @@ Result<CommandResult> cmd_close(const CommandContext &ctx) {
 
     // Find container in room or inventory
     std::shared_ptr<Object> target_obj = nullptr;
-    
+
     // First check inventory
     auto inventory_items = ctx.actor->inventory().get_all_items();
     for (const auto &obj : inventory_items) {
-        if (obj && obj->matches_keyword(target_name)) {
+        if (obj && obj->matches_target_string(target_name)) {
             target_obj = obj;
             break;
         }
     }
-    
+
     // If not found in inventory, check room
     if (!target_obj) {
         auto &room_objects = ctx.room->contents_mutable().objects;
         for (auto &obj : room_objects) {
-            if (obj && obj->matches_keyword(target_name)) {
+            if (obj && obj->matches_target_string(target_name)) {
                 target_obj = obj;
                 break;
             }
@@ -1390,12 +1390,12 @@ Result<CommandResult> cmd_close(const CommandContext &ctx) {
     }
 
     auto container_info = target_obj->container_info();
-    
+
     if (!container_info.closeable) {
         ctx.send_error(fmt::format("The {} cannot be closed.", ctx.format_object_name(target_obj)));
         return CommandResult::InvalidTarget;
     }
-    
+
     if (container_info.closed) {
         ctx.send_error(fmt::format("The {} is already closed.", ctx.format_object_name(target_obj)));
         return CommandResult::InvalidState;
@@ -1425,21 +1425,21 @@ Result<CommandResult> cmd_lock(const CommandContext &ctx) {
 
     // Find container in room or inventory
     std::shared_ptr<Object> target_obj = nullptr;
-    
+
     // First check inventory
     auto inventory_items = ctx.actor->inventory().get_all_items();
     for (const auto &obj : inventory_items) {
-        if (obj && obj->matches_keyword(target_name)) {
+        if (obj && obj->matches_target_string(target_name)) {
             target_obj = obj;
             break;
         }
     }
-    
+
     // If not found in inventory, check room
     if (!target_obj) {
         auto &room_objects = ctx.room->contents_mutable().objects;
         for (auto &obj : room_objects) {
-            if (obj && obj->matches_keyword(target_name)) {
+            if (obj && obj->matches_target_string(target_name)) {
                 target_obj = obj;
                 break;
             }
@@ -1457,17 +1457,17 @@ Result<CommandResult> cmd_lock(const CommandContext &ctx) {
     }
 
     auto container_info = target_obj->container_info();
-    
+
     if (!container_info.lockable) {
         ctx.send_error(fmt::format("The {} cannot be locked.", ctx.format_object_name(target_obj)));
         return CommandResult::InvalidTarget;
     }
-    
+
     if (!container_info.closed) {
         ctx.send_error(fmt::format("You must close {} first before locking it.", ctx.format_object_name(target_obj)));
         return CommandResult::InvalidState;
     }
-    
+
     if (container_info.locked) {
         ctx.send_error(fmt::format("The {} is already locked.", ctx.format_object_name(target_obj)));
         return CommandResult::InvalidState;
@@ -1497,21 +1497,21 @@ Result<CommandResult> cmd_unlock(const CommandContext &ctx) {
 
     // Find container in room or inventory
     std::shared_ptr<Object> target_obj = nullptr;
-    
+
     // First check inventory
     auto inventory_items = ctx.actor->inventory().get_all_items();
     for (const auto &obj : inventory_items) {
-        if (obj && obj->matches_keyword(target_name)) {
+        if (obj && obj->matches_target_string(target_name)) {
             target_obj = obj;
             break;
         }
     }
-    
+
     // If not found in inventory, check room
     if (!target_obj) {
         auto &room_objects = ctx.room->contents_mutable().objects;
         for (auto &obj : room_objects) {
-            if (obj && obj->matches_keyword(target_name)) {
+            if (obj && obj->matches_target_string(target_name)) {
                 target_obj = obj;
                 break;
             }
@@ -1529,12 +1529,12 @@ Result<CommandResult> cmd_unlock(const CommandContext &ctx) {
     }
 
     auto container_info = target_obj->container_info();
-    
+
     if (!container_info.lockable) {
         ctx.send_error(fmt::format("The {} cannot be unlocked.", ctx.format_object_name(target_obj)));
         return CommandResult::InvalidTarget;
     }
-    
+
     if (!container_info.locked) {
         ctx.send_error(fmt::format("The {} is not locked.", ctx.format_object_name(target_obj)));
         return CommandResult::InvalidState;
@@ -1569,7 +1569,7 @@ Result<CommandResult> cmd_light(const CommandContext &ctx) {
 
     // First check equipped items (prioritize what you're holding)
     for (const auto &obj : ctx.actor->equipment().get_all_equipped()) {
-        if (obj && obj->matches_keyword(ctx.arg(0)) && obj->is_light_source()) {
+        if (obj && obj->matches_target_string(ctx.arg(0)) && obj->is_light_source()) {
             light_source = obj;
             break;
         }
@@ -1578,7 +1578,7 @@ Result<CommandResult> cmd_light(const CommandContext &ctx) {
     // If not found in equipped, check inventory
     if (!light_source) {
         for (const auto &obj : ctx.actor->inventory().get_all_items()) {
-            if (obj && obj->matches_keyword(ctx.arg(0)) && obj->is_light_source()) {
+            if (obj && obj->matches_target_string(ctx.arg(0)) && obj->is_light_source()) {
                 light_source = obj;
                 break;
             }
@@ -1633,7 +1633,7 @@ Result<CommandResult> cmd_extinguish(const CommandContext &ctx) {
 
     // First check equipped items (prioritize what you're holding)
     for (const auto &obj : ctx.actor->equipment().get_all_equipped()) {
-        if (obj && obj->matches_keyword(ctx.arg(0)) && obj->is_light_source()) {
+        if (obj && obj->matches_target_string(ctx.arg(0)) && obj->is_light_source()) {
             light_source = obj;
             break;
         }
@@ -1642,7 +1642,7 @@ Result<CommandResult> cmd_extinguish(const CommandContext &ctx) {
     // If not found in equipped, check inventory
     if (!light_source) {
         for (const auto &obj : ctx.actor->inventory().get_all_items()) {
-            if (obj && obj->matches_keyword(ctx.arg(0)) && obj->is_light_source()) {
+            if (obj && obj->matches_target_string(ctx.arg(0)) && obj->is_light_source()) {
                 light_source = obj;
                 break;
             }
@@ -1695,7 +1695,7 @@ Result<CommandResult> cmd_eat(const CommandContext &ctx) {
     std::shared_ptr<Object> food_item = nullptr;
 
     for (const auto &obj : inventory_items) {
-        if (obj && obj->matches_keyword(ctx.arg(0))) {
+        if (obj && obj->matches_target_string(ctx.arg(0))) {
             if (obj->type() == ObjectType::Food || obj->type() == ObjectType::Potion) {
                 food_item = obj;
                 break;
@@ -1908,7 +1908,7 @@ Result<CommandResult> cmd_list(const CommandContext &ctx) {
     // Look for shopkeepers in the room
     const auto& room_contents = ctx.room->contents();
     std::vector<std::shared_ptr<Actor>> shopkeepers;
-    
+
     for (const auto& actor : room_contents.actors) {
         if (auto mobile = std::dynamic_pointer_cast<Mobile>(actor)) {
             if (mobile->is_shopkeeper()) {
@@ -1916,12 +1916,12 @@ Result<CommandResult> cmd_list(const CommandContext &ctx) {
             }
         }
     }
-    
+
     if (shopkeepers.empty()) {
         ctx.send_error("There are no shopkeepers here.");
         return CommandResult::ResourceError;
     }
-    
+
     // Use the first shopkeeper found (could be enhanced to let user choose)
     auto shopkeeper_actor = shopkeepers[0];
     auto shopkeeper_mobile = std::dynamic_pointer_cast<Mobile>(shopkeeper_actor);
@@ -1935,13 +1935,13 @@ Result<CommandResult> cmd_list(const CommandContext &ctx) {
         ctx.send_error("The shopkeeper doesn't seem to be selling anything right now.");
         return CommandResult::ResourceError;
     }
-    
+
     // Display shop listing
     auto listing = shop->get_shop_listing();
     for (const auto& line : listing) {
         ctx.send(line);
     }
-    
+
     return CommandResult::Success;
 }
 
@@ -1961,11 +1961,11 @@ Result<CommandResult> cmd_buy(const CommandContext &ctx) {
     }
 
     std::string item_name{ctx.arg(0)};
-    
+
     // Look for shopkeepers in the room
     const auto& room_contents = ctx.room->contents();
     std::vector<std::shared_ptr<Actor>> shopkeepers;
-    
+
     for (const auto& actor : room_contents.actors) {
         if (auto mobile = std::dynamic_pointer_cast<Mobile>(actor)) {
             if (mobile->is_shopkeeper()) {
@@ -1973,12 +1973,12 @@ Result<CommandResult> cmd_buy(const CommandContext &ctx) {
             }
         }
     }
-    
+
     if (shopkeepers.empty()) {
         ctx.send_error("There are no shopkeepers here.");
         return CommandResult::ResourceError;
     }
-    
+
     // Use the first shopkeeper found
     auto shopkeeper_actor = shopkeepers[0];
     auto shopkeeper_mobile = std::dynamic_pointer_cast<Mobile>(shopkeeper_actor);
@@ -2001,7 +2001,7 @@ Result<CommandResult> cmd_buy(const CommandContext &ctx) {
     for (const auto& item : available_items) {
         // Look up the object prototype to check keywords
         const auto* obj_proto = world.get_object_prototype(item.prototype_id);
-        if (obj_proto && obj_proto->matches_keyword_prefix(item_name)) {
+        if (obj_proto && obj_proto->matches_target_string(item_name)) {
             target_item = &item;
             break;
         }
@@ -2014,7 +2014,7 @@ Result<CommandResult> cmd_buy(const CommandContext &ctx) {
         for (const auto& mob : available_mobs) {
             // Look up the mob prototype to check keywords
             const auto* mob_proto = world.get_mobile_prototype(mob.prototype_id);
-            if (mob_proto && mob_proto->matches_keyword_prefix(item_name)) {
+            if (mob_proto && mob_proto->matches_target_string(item_name)) {
                 target_mob = mob;  // Copy the mob data
                 break;
             }
@@ -2141,7 +2141,7 @@ Result<CommandResult> cmd_sell(const CommandContext &ctx) {
     // Look for shopkeepers in the room
     const auto& room_contents = ctx.room->contents();
     std::vector<std::shared_ptr<Actor>> shopkeepers;
-    
+
     for (const auto& actor : room_contents.actors) {
         if (auto mobile = std::dynamic_pointer_cast<Mobile>(actor)) {
             if (mobile->is_shopkeeper()) {
@@ -2149,12 +2149,12 @@ Result<CommandResult> cmd_sell(const CommandContext &ctx) {
             }
         }
     }
-    
+
     if (shopkeepers.empty()) {
         ctx.send_error("There are no shopkeepers here.");
         return CommandResult::ResourceError;
     }
-    
+
     // Use the first shopkeeper found
     auto shopkeeper_actor = shopkeepers[0];
     auto shopkeeper_mobile = std::dynamic_pointer_cast<Mobile>(shopkeeper_actor);
@@ -2172,20 +2172,20 @@ Result<CommandResult> cmd_sell(const CommandContext &ctx) {
     // Find item in player's inventory (simplified search for now)
     auto inventory_items = ctx.actor->inventory().get_all_items();
     std::shared_ptr<Object> target_object = nullptr;
-    
+
     for (const auto& item : inventory_items) {
-        if (item->name().find(target_name) != std::string::npos || 
+        if (item->name().find(target_name) != std::string::npos ||
             item->name() == target_name) {
             target_object = item;
             break;
         }
     }
-    
+
     if (!target_object) {
         ctx.send_error(fmt::format("You don't have '{}' to sell.", target_name));
         return CommandResult::InvalidTarget;
     }
-    
+
     // Calculate sell price
     int price = shop->calculate_sell_price(*target_object);
 
@@ -2242,7 +2242,7 @@ Result<CommandResult> cmd_hold(const CommandContext &ctx) {
     std::shared_ptr<Object> target_object = nullptr;
 
     for (const auto &obj : inventory_items) {
-        if (obj && obj->matches_keyword(ctx.arg(0))) {
+        if (obj && obj->matches_target_string(ctx.arg(0))) {
             target_object = obj;
             break;
         }
@@ -2284,7 +2284,7 @@ Result<CommandResult> cmd_grab(const CommandContext &ctx) {
     std::shared_ptr<Object> target_object = nullptr;
 
     for (auto &obj : room_objects) {
-        if (obj && obj->matches_keyword(ctx.arg(0))) {
+        if (obj && obj->matches_target_string(ctx.arg(0))) {
             target_object = obj;
             break;
         }
@@ -2336,7 +2336,7 @@ Result<CommandResult> cmd_quaff(const CommandContext &ctx) {
     std::shared_ptr<Object> potion = nullptr;
 
     for (const auto &obj : inventory_items) {
-        if (obj && obj->matches_keyword(ctx.arg(0))) {
+        if (obj && obj->matches_target_string(ctx.arg(0))) {
             if (obj->type() == ObjectType::Potion) {
                 potion = obj;
                 break;
@@ -2391,7 +2391,7 @@ Result<CommandResult> cmd_recite(const CommandContext &ctx) {
     std::shared_ptr<Object> scroll = nullptr;
 
     for (const auto &obj : inventory_items) {
-        if (obj && obj->matches_keyword(ctx.arg(0))) {
+        if (obj && obj->matches_target_string(ctx.arg(0))) {
             if (obj->type() == ObjectType::Scroll) {
                 scroll = obj;
                 break;
@@ -2462,7 +2462,7 @@ Result<CommandResult> cmd_use(const CommandContext &ctx) {
 
     // Check inventory first
     for (const auto &obj : inventory_items) {
-        if (obj && obj->matches_keyword(ctx.arg(0))) {
+        if (obj && obj->matches_target_string(ctx.arg(0))) {
             target_object = obj;
             break;
         }
@@ -2471,7 +2471,7 @@ Result<CommandResult> cmd_use(const CommandContext &ctx) {
     // If not in inventory, check equipment
     if (!target_object) {
         for (const auto &obj : equipped_items) {
-            if (obj && obj->matches_keyword(ctx.arg(0))) {
+            if (obj && obj->matches_target_string(ctx.arg(0))) {
                 target_object = obj;
                 break;
             }
@@ -2567,7 +2567,7 @@ Result<CommandResult> cmd_junk(const CommandContext &ctx) {
     std::shared_ptr<Object> target_object = nullptr;
 
     for (const auto &obj : inventory_items) {
-        if (obj && obj->matches_keyword(ctx.arg(0))) {
+        if (obj && obj->matches_target_string(ctx.arg(0))) {
             target_object = obj;
             break;
         }
@@ -2606,7 +2606,7 @@ Result<CommandResult> cmd_donate(const CommandContext &ctx) {
     std::shared_ptr<Object> target_object = nullptr;
 
     for (const auto &obj : inventory_items) {
-        if (obj && obj->matches_keyword(ctx.arg(0))) {
+        if (obj && obj->matches_target_string(ctx.arg(0))) {
             target_object = obj;
             break;
         }
@@ -2653,14 +2653,14 @@ Result<CommandResult> cmd_compare(const CommandContext &ctx) {
 
     // Search for first item
     for (const auto &obj : inventory_items) {
-        if (obj && obj->matches_keyword(ctx.arg(0))) {
+        if (obj && obj->matches_target_string(ctx.arg(0))) {
             item1 = obj;
             break;
         }
     }
     if (!item1) {
         for (const auto &obj : equipped_items) {
-            if (obj && obj->matches_keyword(ctx.arg(0))) {
+            if (obj && obj->matches_target_string(ctx.arg(0))) {
                 item1 = obj;
                 break;
             }
@@ -2669,14 +2669,14 @@ Result<CommandResult> cmd_compare(const CommandContext &ctx) {
 
     // Search for second item
     for (const auto &obj : inventory_items) {
-        if (obj && obj->matches_keyword(ctx.arg(1)) && obj != item1) {
+        if (obj && obj->matches_target_string(ctx.arg(1)) && obj != item1) {
             item2 = obj;
             break;
         }
     }
     if (!item2) {
         for (const auto &obj : equipped_items) {
-            if (obj && obj->matches_keyword(ctx.arg(1)) && obj != item1) {
+            if (obj && obj->matches_target_string(ctx.arg(1)) && obj != item1) {
                 item2 = obj;
                 break;
             }
@@ -2741,7 +2741,7 @@ Result<CommandResult> cmd_fill(const CommandContext &ctx) {
     std::shared_ptr<Object> container = nullptr;
 
     for (const auto &obj : inventory_items) {
-        if (obj && obj->matches_keyword(ctx.arg(0))) {
+        if (obj && obj->matches_target_string(ctx.arg(0))) {
             if (obj->type() == ObjectType::Drinkcontainer) {
                 container = obj;
                 break;
@@ -2831,7 +2831,7 @@ Result<CommandResult> cmd_pour(const CommandContext &ctx) {
     std::shared_ptr<Object> source = nullptr;
 
     for (const auto &obj : inventory_items) {
-        if (obj && obj->matches_keyword(ctx.arg(0))) {
+        if (obj && obj->matches_target_string(ctx.arg(0))) {
             if (obj->type() == ObjectType::Drinkcontainer) {
                 source = obj;
                 break;
@@ -2867,7 +2867,7 @@ Result<CommandResult> cmd_pour(const CommandContext &ctx) {
     // Find target container
     std::shared_ptr<Object> target = nullptr;
     for (const auto &obj : inventory_items) {
-        if (obj && obj->matches_keyword(ctx.arg(1)) && obj != source) {
+        if (obj && obj->matches_target_string(ctx.arg(1)) && obj != source) {
             if (obj->type() == ObjectType::Drinkcontainer) {
                 target = obj;
                 break;

--- a/src/core/entity.cpp
+++ b/src/core/entity.cpp
@@ -14,11 +14,9 @@ namespace {
 
 // Entity Implementation
 
-Entity::Entity(EntityId id, std::string_view name) 
+Entity::Entity(EntityId id, std::string_view name)
     : id_(id), name_(name) {
-    if (!name.empty()) {
-        ensure_name_in_keywords();
-    }
+    ensure_name_in_keywords();
 }
 
 Entity::Entity(EntityId id, std::string_view name,
@@ -26,25 +24,13 @@ Entity::Entity(EntityId id, std::string_view name,
                std::string_view ground,
                std::string_view short_desc)
     : id_(id), name_(name), ground_(ground), short_(short_desc) {
-
-    keywords_.reserve(keywords.size() + 1);
-    for (const auto& keyword : keywords) {
-        if (EntityUtils::is_valid_keyword(keyword)) {
-            std::string normalized = EntityUtils::normalize_keyword(keyword);
-            if (keyword_set_.find(normalized) == keyword_set_.end()) {
-                keywords_.push_back(normalized);
-                keyword_set_.insert(normalized);
-            }
-        }
-    }
-
-    ensure_name_in_keywords();
+    set_keywords(keywords);
 }
 
 bool Entity::matches_keyword(std::string_view keyword) const {
     std::string normalized = EntityUtils::normalize_keyword(keyword);
-    // O(1) lookup using unordered_set instead of O(n) linear search
-    return keyword_set_.find(normalized) != keyword_set_.end();
+    // O(log n) lookup using set instead of O(n) linear search
+    return keyword_set_.contains(normalized);
 }
 
 bool Entity::matches_keyword_prefix(std::string_view prefix) const {
@@ -53,51 +39,11 @@ bool Entity::matches_keyword_prefix(std::string_view prefix) const {
     }
 
     std::string normalized_prefix = EntityUtils::normalize_keyword(prefix);
-
-    // First try exact match (O(1))
-    if (keyword_set_.find(normalized_prefix) != keyword_set_.end()) {
-        return true;
-    }
-
-    // Then try prefix match (O(n) but keywords are usually few)
-    for (const auto& keyword : keywords_) {
-        if (keyword.starts_with(normalized_prefix)) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
-bool Entity::matches_target_string(std::string_view target) const {
-    if (target.empty()) {
+    auto iter = keyword_set_.lower_bound(normalized_prefix);
+    if (iter == keyword_set_.end()) {
         return false;
     }
-
-    // Check for compound keyword (contains hyphen)
-    size_t hyphen_pos = target.find('-');
-    if (hyphen_pos == std::string_view::npos) {
-        // No hyphen - use regular prefix matching
-        return matches_keyword_prefix(target);
-    }
-
-    // Split on hyphens and require ALL parts to match
-    size_t start = 0;
-    while (start < target.size()) {
-        size_t end = target.find('-', start);
-        if (end == std::string_view::npos) {
-            end = target.size();
-        }
-
-        std::string_view part = target.substr(start, end - start);
-        if (!part.empty() && !matches_keyword_prefix(part)) {
-            return false;  // One part didn't match, fail
-        }
-
-        start = end + 1;
-    }
-
-    return true;  // All parts matched
+    return !iter->starts_with(normalized_prefix);
 }
 
 bool Entity::matches_any_keyword(std::span<const std::string> keywords) const {
@@ -113,15 +59,7 @@ void Entity::set_keywords(std::span<const std::string> new_keywords) {
     keywords_.reserve(new_keywords.size() + 1);
 
     for (const auto& keyword : new_keywords) {
-        if (EntityUtils::is_valid_keyword(keyword)) {
-            std::string normalized = EntityUtils::normalize_keyword(keyword);
-
-            // O(1) duplicate check using set
-            if (keyword_set_.find(normalized) == keyword_set_.end()) {
-                keywords_.push_back(normalized);
-                keyword_set_.insert(std::move(normalized));
-            }
-        }
+        add_keyword(keyword);
     }
 
     ensure_name_in_keywords();
@@ -134,10 +72,10 @@ void Entity::add_keyword(std::string_view keyword) {
 
     std::string normalized = EntityUtils::normalize_keyword(keyword);
 
-    // O(1) duplicate check using set
-    if (keyword_set_.find(normalized) == keyword_set_.end()) {
-        keywords_.push_back(normalized);
-        keyword_set_.insert(std::move(normalized));
+    // O(log n) duplicate check using set
+    auto [_, inserted] = keyword_set_.insert(normalized);
+    if (inserted) {
+        keywords_.push_back(std::move(normalized));
     }
 }
 
@@ -159,17 +97,17 @@ void Entity::remove_keyword(std::string_view keyword) {
 
 nlohmann::json Entity::to_json() const {
     nlohmann::json json;
-    
+
     json["type"] = type_name();
     json["id"] = id_.value();
     json["name"] = name_;
     json["keywords"] = keywords_;
     json["ground"] = ground_;
-    
+
     if (!short_.empty()) {
         json["short"] = short_;
     }
-    
+
     return json;
 }
 
@@ -179,7 +117,7 @@ Result<std::unique_ptr<Entity>> Entity::from_json(const nlohmann::json& json) {
         if (!json.contains("id")) {
             return std::unexpected(Errors::ParseError("Entity JSON missing 'id' field"));
         }
-        
+
         // Handle name field mapping: name -> short -> keywords -> name_list (legacy)
         std::string name;
         if (json.contains("name")) {
@@ -204,7 +142,7 @@ Result<std::unique_ptr<Entity>> Entity::from_json(const nlohmann::json& json) {
         } else {
             return std::unexpected(Errors::ParseError("Entity JSON missing 'name', 'short', 'keywords', or 'name_list' field"));
         }
-        
+
         // Handle ID conversion
         EntityId id;
         if (json["id"].is_string()) {
@@ -214,9 +152,9 @@ Result<std::unique_ptr<Entity>> Entity::from_json(const nlohmann::json& json) {
         } else {
             id = EntityId{json["id"].get<std::uint64_t>()};
         }
-        
+
         auto entity = std::unique_ptr<Entity>(new Entity(id, name));
-        
+
         // Parse optional fields with field mapping (new and legacy field names)
         if (json.contains("ground")) {
             entity->set_ground(json["ground"].get<std::string>());
@@ -225,7 +163,7 @@ Result<std::unique_ptr<Entity>> Entity::from_json(const nlohmann::json& json) {
         } else if (json.contains("long_description")) {
             entity->set_ground(json["long_description"].get<std::string>());
         }
-        
+
         if (json.contains("short")) {
             entity->set_short_desc(json["short"].get<std::string>());
         } else if (json.contains("short_desc")) {
@@ -233,7 +171,7 @@ Result<std::unique_ptr<Entity>> Entity::from_json(const nlohmann::json& json) {
         } else if (json.contains("short_description")) {
             entity->set_short_desc(json["short_description"].get<std::string>());
         }
-        
+
         // Parse keywords from array or space-separated string
         // Priority: keywords (array) -> keywords (string) -> name_list (legacy)
         std::vector<std::string> keywords;
@@ -261,15 +199,15 @@ Result<std::unique_ptr<Entity>> Entity::from_json(const nlohmann::json& json) {
                 keywords.push_back(keyword);
             }
         }
-        
+
         if (!keywords.empty()) {
             entity->set_keywords(keywords);
         }
-        
+
         TRY(entity->validate());
-        
+
         return entity;
-        
+
     } catch (const nlohmann::json::exception& e) {
         return std::unexpected(Errors::ParseError("Entity JSON parsing", e.what()));
     }
@@ -303,15 +241,15 @@ Result<void> Entity::validate() const {
     if (!id_.is_valid()) {
         return std::unexpected(Errors::InvalidState("Entity has invalid ID"));
     }
-    
+
     if (name_.empty()) {
         return std::unexpected(Errors::InvalidState("Entity name cannot be empty"));
     }
-    
+
     if (keywords_.empty()) {
         return std::unexpected(Errors::InvalidState("Entity must have at least one keyword"));
     }
-    
+
     return Success();
 }
 
@@ -328,18 +266,18 @@ Result<std::unique_ptr<Entity>> EntityFactory::create_from_json(const nlohmann::
         if (!json.contains("type")) {
             return std::unexpected(Errors::ParseError("JSON missing 'type' field"));
         }
-        
+
         std::string type = json["type"].get<std::string>();
-        
+
         auto it = creators_.find(type);
         if (it == creators_.end()) {
             // Fallback to base Entity if specific type not registered
             Log::debug("Unknown entity type '{}', using base Entity", type);
             return create_base_entity_from_json(json);
         }
-        
+
         return it->second(json);
-        
+
     } catch (const nlohmann::json::exception& e) {
         return std::unexpected(Errors::ParseError("JSON parsing error", e.what()));
     }
@@ -348,11 +286,11 @@ Result<std::unique_ptr<Entity>> EntityFactory::create_from_json(const nlohmann::
 std::vector<std::string> EntityFactory::get_registered_types() {
     std::vector<std::string> types;
     types.reserve(creators_.size());
-    
+
     for (const auto& [type_name, creator] : creators_) {
         types.push_back(type_name);
     }
-    
+
     std::sort(types.begin(), types.end());
     return types;
 }
@@ -363,9 +301,9 @@ Result<std::unique_ptr<Entity>> EntityFactory::create_base_entity_from_json(cons
         if (!json.contains("id")) {
             return std::unexpected(Errors::ParseError("Entity JSON missing 'id' field"));
         }
-        
+
         EntityId id{json["id"].get<std::uint64_t>()};
-        
+
         // Handle name field mapping: name -> short -> keywords fallback
         std::string name;
         if (json.contains("name")) {
@@ -383,16 +321,16 @@ Result<std::unique_ptr<Entity>> EntityFactory::create_base_entity_from_json(cons
         } else {
             return std::unexpected(Errors::ParseError("Entity JSON missing 'name', 'short', or 'keywords' field"));
         }
-        
+
         auto entity = std::unique_ptr<Entity>(new Entity(id, name));
-        
+
         // Parse optional fields (new and legacy field names)
         if (json.contains("ground")) {
             entity->set_ground(json["ground"].get<std::string>());
         } else if (json.contains("description")) {
             entity->set_ground(json["description"].get<std::string>());
         }
-        
+
         if (json.contains("short")) {
             entity->set_short_desc(json["short"].get<std::string>());
         } else if (json.contains("short_desc")) {
@@ -400,7 +338,7 @@ Result<std::unique_ptr<Entity>> EntityFactory::create_base_entity_from_json(cons
         } else if (json.contains("short_description")) {
             entity->set_short_desc(json["short_description"].get<std::string>());
         }
-        
+
         if (json.contains("keywords") && json["keywords"].is_array()) {
             std::vector<std::string> keywords;
             for (const auto& keyword : json["keywords"]) {
@@ -412,11 +350,11 @@ Result<std::unique_ptr<Entity>> EntityFactory::create_base_entity_from_json(cons
                 entity->set_keywords(keywords);
             }
         }
-        
+
         TRY(entity->validate());
-        
+
         return entity;
-        
+
     } catch (const nlohmann::json::exception& e) {
         return std::unexpected(Errors::ParseError("Entity JSON parsing", e.what()));
     }
@@ -426,7 +364,7 @@ Result<std::unique_ptr<Entity>> EntityFactory::create_base_entity_from_json(cons
 
 namespace EntityUtils {
     // Common articles that should not be keywords
-    static const std::unordered_set<std::string> ARTICLES = {"a", "an", "the", "some"};
+    static const std::set<std::string> ARTICLES = {"a", "an", "the", "some"};
 
     bool is_valid_keyword(std::string_view keyword) {
         if (keyword.empty() || keyword.length() > MAX_KEYWORD_LENGTH) {
@@ -452,36 +390,38 @@ namespace EntityUtils {
 
         return true;
     }
-    
+
     std::string normalize_keyword(std::string_view keyword) {
         std::string normalized;
         normalized.reserve(keyword.length());
-        
-        // Convert to lowercase and trim spaces
+
+        // Convert to lowercase and simplify separators
         bool in_word = false;
         for (char c : keyword) {
             if (std::isspace(c)) {
-                if (in_word) {
-                    normalized.push_back(' ');
-                    in_word = false;
-                }
+                c = ' ';
             } else {
-                normalized.push_back(std::tolower(c));
-                in_word = true;
+                c = std::tolower(c);
             }
+            bool is_space = (c == ' ' || c == '-');
+            if (is_space && !in_word) {
+                continue;
+            }
+            normalized.push_back(c);
+            in_word = !is_space;
         }
-        
+
         // Remove trailing space if any
         if (!normalized.empty() && normalized.back() == ' ') {
             normalized.pop_back();
         }
-        
+
         return normalized;
     }
-    
+
     std::vector<std::string> parse_keyword_list(std::string_view keyword_string) {
         std::vector<std::string> keywords;
-        
+
         // Split on whitespace and filter valid keywords
         std::string current;
         for (char c : keyword_string) {
@@ -496,19 +436,19 @@ namespace EntityUtils {
                 current.push_back(c);
             }
         }
-        
+
         // Handle last keyword
         if (!current.empty() && EntityUtils::is_valid_keyword(current)) {
             keywords.push_back(EntityUtils::normalize_keyword(current));
         }
-        
+
         // Remove duplicates
         std::sort(keywords.begin(), keywords.end());
         keywords.erase(std::unique(keywords.begin(), keywords.end()), keywords.end());
-        
+
         return keywords;
     }
-    
+
     std::string create_keyword_string(std::span<const std::string> keywords) {
         if (keywords.empty()) {
             return "";
@@ -527,48 +467,79 @@ namespace EntityUtils {
 
         return result;
     }
-    
+
     std::string_view get_article(std::string_view name, bool definite) {
         if (definite) {
             return "the";
         }
-        
+
         if (name.empty()) {
             return "a";
         }
-        
+
         char first = std::tolower(name[0]);
         if (first == 'a' || first == 'e' || first == 'i' || first == 'o' || first == 'u') {
             return "an";
         }
-        
+
         return "a";
     }
-    
-    std::string format_entity_name(std::string_view name, std::string_view short_desc, 
-                             bool with_article, bool definite_article) {
-    std::string display_name = short_desc.empty() ? std::string(name) : std::string(short_desc);
-    
-    if (with_article) {
-        // Check if display_name already starts with an article
-        std::string lower_display = to_lowercase(display_name);
 
-        // Common articles and demonstratives
-        if (lower_display.starts_with("a ") || 
-            lower_display.starts_with("an ") || 
-            lower_display.starts_with("the ") ||
-            lower_display.starts_with("some ") ||
-            lower_display.starts_with("this ") ||
-            lower_display.starts_with("that ")) {
-            return display_name; // Already has article, don't add another
+    std::string format_entity_name(std::string_view name, std::string_view short_desc,
+                                   bool with_article, bool definite_article) {
+        std::string display_name = short_desc.empty() ? std::string(name) : std::string(short_desc);
+
+        if (with_article) {
+            // Check if display_name already starts with an article
+            std::string lower_display = to_lowercase(display_name);
+
+            // Common articles and demonstratives
+            if (lower_display.starts_with("a ") ||
+                lower_display.starts_with("an ") ||
+                lower_display.starts_with("the ") ||
+                lower_display.starts_with("some ") ||
+                lower_display.starts_with("this ") ||
+                lower_display.starts_with("that ")) {
+                return display_name; // Already has article, don't add another
+            }
+
+            std::string_view article = EntityUtils::get_article(display_name, definite_article);
+            return fmt::format("{} {}", article, display_name);
         }
-        
-        std::string_view article = EntityUtils::get_article(display_name, definite_article);
-        return fmt::format("{} {}", article, display_name);
+
+        return display_name;
     }
-    
-    return display_name;
-}
+
+    bool matches_target_string(const std::set<std::string>& keywords, std::string_view target) {
+        if (target.empty()) {
+            return false;
+        }
+
+        auto words = EntityUtils::normalize_keyword(target) | std::views::split('-');
+
+        for (const auto& split : words) {
+            std::string word{std::string_view(split)};
+            auto iter = keywords.lower_bound(word);
+            if (iter == keywords.end()) {
+                return false;
+            }
+            if (!iter->starts_with(word)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    std::set<std::string> parse_target_string(std::string_view target) {
+        auto words = EntityUtils::normalize_keyword(target) | std::views::split('-');
+
+        std::set<std::string> parsed;
+        for (const auto& split : words) {
+            parsed.emplace(split.begin(), split.end());
+        }
+        return parsed;
+    }
 }
 
 // JSON Support Functions

--- a/src/core/object.hpp
+++ b/src/core/object.hpp
@@ -28,7 +28,7 @@ enum class EquipSlot {
     None = -1,          // Not wearable
     Light = 0,          // Light source slot
     Finger_R = 1,       // Right finger
-    Finger_L = 2,       // Left finger  
+    Finger_L = 2,       // Left finger
     Neck1 = 3,          // First neck slot
     Neck2 = 4,          // Second neck slot
     Body = 5,           // Main body armor
@@ -62,12 +62,12 @@ struct DamageProfile {
     int dice_count = 0;         // Number of damage dice
     int dice_sides = 0;         // Sides per damage die
     int damage_bonus = 0;       // Flat damage bonus
-    
+
     /** Calculate average damage */
     double average_damage() const {
         return base_damage + damage_bonus + (dice_count * (dice_sides + 1)) / 2.0;
     }
-    
+
     /** Format as dice notation (e.g., "1d8+2") */
     std::string to_dice_string() const;
 };
@@ -76,7 +76,7 @@ struct DamageProfile {
 struct ExtraDescription {
     std::vector<std::string> keywords;  // Keywords that trigger this description
     std::string description;            // The detailed description text
-    
+
     /** Check if any keyword matches */
     bool matches_keyword(std::string_view keyword) const {
         for (const auto& kw : keywords) {
@@ -240,51 +240,51 @@ class Object : public Entity {
 public:
     /** Create object with basic properties */
     static Result<std::unique_ptr<Object>> create(EntityId id, std::string_view name, ObjectType type);
-    
+
     /** Load object from JSON */
     static Result<std::unique_ptr<Object>> from_json(const nlohmann::json& json);
-    
+
     /** Virtual destructor */
     virtual ~Object() = default;
-    
+
     /** Get object type */
     ObjectType type() const { return type_; }
-    
+
     /** Get total weight in pounds (virtual - containers override to include contents) */
     virtual int weight() const { return weight_; }
 
     /** Get base weight (excluding contents for containers) */
     int base_weight() const { return weight_; }
-    
+
     /** Get base value in copper coins */
     int value() const { return value_; }
-    
+
     /** Get object level requirement */
     int level() const { return level_; }
-    
+
     /** Get wear slot if wearable */
     EquipSlot equip_slot() const { return equip_slot_; }
-    
+
     /** Check if object can be worn/wielded */
     bool is_wearable() const { return equip_slot_ != EquipSlot::None; }
 
     /** Check if object can be picked up (has TAKE wear flag) */
     bool can_take() const { return can_take_; }
     void set_can_take(bool value) { can_take_ = value; }
-    
+
     /** Check if object is a weapon */
-    bool is_weapon() const { 
-        return type_ == ObjectType::Weapon || type_ == ObjectType::Fireweapon; 
+    bool is_weapon() const {
+        return type_ == ObjectType::Weapon || type_ == ObjectType::Fireweapon;
     }
-    
+
     /** Check if object is armor */
     bool is_armor() const { return type_ == ObjectType::Armor; }
-    
+
     /** Check if object is a container (includes corpses which hold loot) */
     bool is_container() const {
         return type_ == ObjectType::Container || type_ == ObjectType::Drinkcontainer || type_ == ObjectType::Corpse;
     }
-    
+
     /** Check if object is a light source */
     bool is_light_source() const { return type_ == ObjectType::Light; }
 
@@ -331,7 +331,7 @@ public:
     void set_charges(int c) { charges_ = std::max(0, c); }
     int max_charges() const { return max_charges_; }
     void set_max_charges(int c) { max_charges_ = std::max(0, c); }
-    
+
     /** Check if object has a specific flag */
     bool has_flag(ObjectFlag flag) const;
 
@@ -355,7 +355,7 @@ public:
 
     /** Get all effect flags */
     const std::unordered_set<EffectFlag>& effect_flags() const { return effect_flags_; }
-    
+
     /** Get damage profile (for weapons) */
     const DamageProfile& damage_profile() const { return damage_profile_; }
 
@@ -376,16 +376,16 @@ public:
      * Non-weapon objects return Medium as default
      */
     WeaponSpeed weapon_speed() const;
-    
+
     /** Get container info (for containers) */
     const ContainerInfo& container_info() const { return container_info_; }
-    
+
     /** Set container properties */
     void set_container_info(const ContainerInfo& info) { container_info_ = info; }
-    
+
     /** Get light info (for light sources) */
     const LightInfo& light_info() const { return light_info_; }
-    
+
     /** Set light properties */
     void set_light_info(const LightInfo& info) { light_info_ = info; }
 
@@ -393,7 +393,7 @@ public:
     const LiquidInfo& liquid_info() const { return liquid_info_; }
 
     /** Set liquid properties */
-    void set_liquid_info(const LiquidInfo& info) { liquid_info_ = info; }
+    void set_liquid_info(const LiquidInfo& info);
 
     /** Check if container has liquid (fountains always have liquid - infinite supply) */
     bool has_liquid() const {
@@ -408,48 +408,45 @@ public:
 
     /** Get armor class bonus (for armor) */
     int armor_class() const { return armor_class_; }
-    
+
     /** Set armor class */
     void set_armor_class(int ac) { armor_class_ = ac; }
-    
+
     /** Get condition/durability (0-100) */
     int condition() const { return condition_; }
-    
+
     /** Set condition */
-    void set_condition(int cond) { 
-        condition_ = std::max(0, std::min(100, cond)); 
+    void set_condition(int cond) {
+        condition_ = std::max(0, std::min(100, cond));
     }
-    
+
     /** Check if object is broken/destroyed */
     bool is_broken() const { return condition_ <= 0; }
-    
+
     /** Get timer value (for timed objects) */
     int timer() const { return timer_; }
-    
+
     /** Set timer value */
     void set_timer(int t) { timer_ = std::max(0, t); }
-    
+
     /** Check if object has expired */
     bool is_expired() const { return timer_ == 0 && has_timer_; }
-    
+
     /** Set properties */
     void set_weight(int w) { weight_ = std::max(0, w); }
     void set_value(int v) { value_ = std::max(0, v); }
     void set_level(int l) { level_ = std::max(0, l); }
     void set_equip_slot(EquipSlot slot) { equip_slot_ = slot; }
     void set_type(ObjectType new_type) { type_ = new_type; }
-    
+
     /** JSON serialization */
     nlohmann::json to_json() const override;
-    
+
     /** Get entity type name */
     std::string_view type_name() const override { return "Object"; }
 
     /** Validation */
     Result<void> validate() const override;
-
-    /** Override matches_keyword to also match liquid type for identified drink containers */
-    bool matches_keyword(std::string_view keyword) const override;
 
     /** Override display_name to use dynamic article and base_name for drink/container state */
     std::string display_name(bool with_article = false) const override;
@@ -468,10 +465,10 @@ public:
      * @param force_identified Treat as identified even if flag not set (for shop displays)
      */
     std::string display_name_with_condition(bool with_article = false, bool force_identified = false) const;
-    
+
     /** Get quality description based on condition */
     std::string_view quality_description() const;
-    
+
     /** Examine description - detailed text shown when looking at the object */
     std::string_view examine_description() const { return examine_description_; }
     void set_examine_description(std::string_view desc) { examine_description_ = desc; }
@@ -488,14 +485,14 @@ public:
     void add_extra_description(const ExtraDescription& extra_desc);
     std::optional<std::string_view> get_extra_description(std::string_view keyword) const;
     const std::vector<ExtraDescription>& get_all_extra_descriptions() const { return extra_descriptions_; }
-    
+
     /** Get comprehensive stat information for debugging/admin commands */
     virtual std::string get_stat_info() const;
-    
+
 protected:
     /** Constructor for derived classes */
     Object(EntityId id, std::string_view name, ObjectType type);
-    
+
 private:
     ObjectType type_ = ObjectType::Nothing;
     int weight_ = 0;
@@ -536,26 +533,26 @@ class Weapon : public Object {
 public:
     static Result<std::unique_ptr<Weapon>> create(EntityId id, std::string_view name,
                                                 ObjectType weapon_type = ObjectType::Weapon);
-    
+
     std::string_view type_name() const override { return "Weapon"; }
-    
+
     /** Get comprehensive stat information including weapon details */
     std::string get_stat_info() const override;
-    
+
     /** Get weapon type (melee vs ranged) */
     bool is_ranged() const { return type() == ObjectType::Fireweapon; }
-    
+
     /** Get weapon reach in feet */
     int reach() const { return reach_; }
     void set_reach(int r) { reach_ = std::max(0, r); }
-    
+
     /** Get weapon speed (lower is faster) */
     int speed() const { return speed_; }
     void set_speed(int s) { speed_ = std::max(1, s); }
-    
+
 protected:
     Weapon(EntityId id, std::string_view name, ObjectType type);
-    
+
 private:
     int reach_ = 5;     // Weapon reach in feet
     int speed_ = 5;     // Attack speed (1-10, lower is faster)
@@ -563,21 +560,21 @@ private:
 
 class Armor : public Object {
 public:
-    static Result<std::unique_ptr<Armor>> create(EntityId id, std::string_view name, 
+    static Result<std::unique_ptr<Armor>> create(EntityId id, std::string_view name,
                                                EquipSlot slot = EquipSlot::Body);
-    
+
     std::string_view type_name() const override { return "Armor"; }
-    
+
     /** Get comprehensive stat information including armor details */
     std::string get_stat_info() const override;
-    
+
     /** Get armor material type */
     std::string_view material() const { return material_; }
     void set_material(std::string_view mat) { material_ = mat; }
-    
+
 protected:
     Armor(EntityId id, std::string_view name, EquipSlot slot);
-    
+
 private:
     std::string material_ = "leather";
 };
@@ -587,7 +584,7 @@ public:
     static Result<std::unique_ptr<Container>> create(EntityId id, std::string_view name,
                                                    int capacity = 10,
                                                    ObjectType type = ObjectType::Container);
-    
+
     std::string_view type_name() const override { return "Container"; }
 
     /** Override weight to include contents */
@@ -600,7 +597,7 @@ public:
     bool can_store_item(const Object& item) const;
     int current_capacity() const { return current_items_; }
     int contents_weight() const { return current_weight_; }
-    
+
     /** Container inventory management */
     Result<void> add_item(std::shared_ptr<Object> item);
 
@@ -620,21 +617,21 @@ public:
     size_t contents_count() const { return contents_.size(); }
     bool is_empty() const { return contents_.empty(); }
     bool is_full() const { return current_items_ >= container_info().capacity; }
-    
+
     /** Update capacity tracking - deprecated, use add_item/remove_item */
-    void add_item_tracking(int weight = 1) { 
+    void add_item_tracking(int weight = 1) {
         current_items_++;
         current_weight_ += weight;
     }
-    
+
     void remove_item_tracking(int weight = 1) {
         current_items_ = std::max(0, current_items_ - 1);
         current_weight_ = std::max(0, current_weight_ - weight);
     }
-    
+
 protected:
     Container(EntityId id, std::string_view name, int capacity, ObjectType type = ObjectType::Container);
-    
+
 private:
     std::vector<std::shared_ptr<Object>> contents_;
     int current_items_ = 0;
@@ -645,28 +642,28 @@ private:
 namespace ObjectUtils {
     /** Get object type name as string */
     std::string_view get_type_name(ObjectType type);
-    
+
     /** Parse object type from string */
     std::optional<ObjectType> parse_object_type(std::string_view type_name);
-    
+
     /** Get equip slot name as string */
     std::string_view get_slot_name(EquipSlot slot);
-    
+
     /** Parse equip slot from string */
     std::optional<EquipSlot> parse_equip_slot(std::string_view slot_name);
-    
+
     /** Check if object type can be equipped in slot */
     bool can_equip_in_slot(ObjectType type, EquipSlot slot);
-    
+
     /** Get default equip slot for object type */
     EquipSlot get_default_slot(ObjectType type);
-    
+
     /** Calculate object value based on properties */
     int calculate_base_value(ObjectType type, int level = 1);
-    
+
     /** Get condition color code for display */
     std::string_view get_condition_color(int condition);
-    
+
     /** Format damage profile as string */
     std::string format_damage_profile(const DamageProfile& damage);
 }
@@ -679,7 +676,7 @@ void from_json(const nlohmann::json& json, std::unique_ptr<Object>& object);
 template<>
 struct fmt::formatter<ObjectType> {
     constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
-    
+
     template<typename FormatContext>
     auto format(ObjectType type, FormatContext& ctx) const {
         return fmt::format_to(ctx.out(), "{}", ObjectUtils::get_type_name(type));
@@ -689,7 +686,7 @@ struct fmt::formatter<ObjectType> {
 template<>
 struct fmt::formatter<EquipSlot> {
     constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
-    
+
     template<typename FormatContext>
     auto format(EquipSlot slot, FormatContext& ctx) const {
         return fmt::format_to(ctx.out(), "{}", ObjectUtils::get_slot_name(slot));

--- a/src/world/room.cpp
+++ b/src/world/room.cpp
@@ -247,7 +247,7 @@ std::vector<std::shared_ptr<Object>> RoomContents::find_objects_by_keyword(std::
     std::vector<std::shared_ptr<Object>> results;
 
     for (const auto &obj : objects) {
-        if (obj && obj->matches_keyword(keyword)) {
+        if (obj && obj->matches_target_string(keyword)) {
             results.push_back(obj);
         }
     }
@@ -259,7 +259,7 @@ std::vector<std::shared_ptr<Actor>> RoomContents::find_actors_by_keyword(std::st
     std::vector<std::shared_ptr<Actor>> results;
 
     for (const auto &actor : actors) {
-        if (actor && actor->matches_keyword(keyword)) {
+        if (actor && actor->matches_target_string(keyword)) {
             results.push_back(actor);
         }
     }

--- a/src/world/world_manager.cpp
+++ b/src/world/world_manager.cpp
@@ -77,19 +77,19 @@ Result<void> WorldManager::initialize(const std::string& world_path, bool load_f
 
 void WorldManager::shutdown() {
     std::unique_lock lock(world_mutex_);
-    
+
     if (!initialized_.load()) {
         return;
     }
-    
+
     auto logger = Log::game();
     logger->info("Shutting down WorldManager");
-      
+
     clear_state();
-    
+
     initialized_.store(false);
     has_unsaved_changes_.store(false);
-    
+
     logger->info("WorldManager shutdown complete");
 }
 
@@ -156,16 +156,16 @@ bool WorldManager::should_shutdown_now() const {
 Result<void> WorldManager::load_world() {
     // Note: This method is called from the world strand - no mutex needed!
     // The strand provides single-threaded access by design.
-    
+
     if (!initialized_.load()) {
         return std::unexpected(Errors::InvalidState("WorldManager not initialized"));
     }
-    
+
     auto start_time = std::chrono::steady_clock::now();
     auto logger = Log::game();
 
     logger->info("Loading world from database...");
-    
+
     // Clear existing data
     rooms_.clear();
     zones_.clear();
@@ -205,14 +205,14 @@ Result<void> WorldManager::load_world() {
 
     // Load board data from database
     board_system().load_boards();
-    
+
     // Update statistics
     auto end_time = std::chrono::steady_clock::now();
     stats_.load_time = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time);
-    
+
     logger->info("World loading complete: {} zones, {} rooms loaded in {}ms",
                 stats_.zones_loaded, stats_.rooms_loaded, stats_.load_time.count());
-    
+
     // Validate world integrity
     auto validation = validate_world();
     if (!validation.is_valid) {
@@ -224,13 +224,13 @@ Result<void> WorldManager::load_world() {
             logger->warn("World validation warning: {}", warning);
         }
     }
-    
+
     update_file_timestamps();
     has_unsaved_changes_.store(false);
-    
+
     // Initialize weather system for loaded zones
     initialize_weather_callbacks();
-    
+
     // Force initial zone resets to spawn mobiles and populate the world
     logger->info("Performing initial zone resets to populate world...");
     for (const auto& [zone_id, zone] : zones_) {
@@ -241,21 +241,21 @@ Result<void> WorldManager::load_world() {
         }
     }
     logger->info("Initial zone resets completed - world populated with mobiles and objects");
-    
+
     return Success();
 }
 
 Result<void> WorldManager::load_zone_file(const std::string& filename) {
     auto logger = Log::game();
     logger->debug("Loading zone file: {}", filename);
-    
+
     // Load JSON zone file
     std::ifstream file(filename);
     if (!file.is_open()) {
         stats_.failed_zone_loads++;
         return std::unexpected(Errors::FileNotFound(filename));
     }
-    
+
     nlohmann::json zone_json;
     try {
         file >> zone_json;
@@ -263,12 +263,12 @@ Result<void> WorldManager::load_zone_file(const std::string& filename) {
         stats_.failed_zone_loads++;
         return std::unexpected(Errors::ParseError("Zone JSON", e.what()));
     }
-    
+
     // Extract zone data from the nested JSON structure
     nlohmann::json zone_data;
     if (zone_json.contains("zone") && zone_json["zone"].is_object()) {
         zone_data = zone_json["zone"];
-        
+
         // Convert numeric ID to proper format expected by modern system
         if (zone_data.contains("id") && zone_data["id"].is_string()) {
             try {
@@ -287,25 +287,25 @@ Result<void> WorldManager::load_zone_file(const std::string& filename) {
         // Fall back to direct zone_json if it's in the modern format
         zone_data = zone_json;
     }
-    
+
     // Create the zone first - pass the full JSON structure
     auto zone_result = Zone::from_json(zone_json);
     if (!zone_result) {
         stats_.failed_zone_loads++;
         return std::unexpected(zone_result.error());
     }
-    
+
     auto zone = std::move(zone_result.value());
     auto zone_id = zone->id();
     auto zone_name = zone->name();
-    
+
     // Add zone to the registry first so it's available for spawning
     auto zone_shared = std::shared_ptr<Zone>(zone.release());
     zones_[zone_id] = zone_shared;
-    
+
     // Set up zone reset callbacks
     setup_zone_callbacks(zone_shared);
-    
+
     // Parse embedded rooms and add them to the world
     if (zone_json.contains("rooms") && zone_json["rooms"].is_array()) {
         for (const auto& room_json : zone_json["rooms"]) {
@@ -315,17 +315,17 @@ Result<void> WorldManager::load_zone_file(const std::string& filename) {
                 auto room_result = Room::from_json(room_json);
                 if (room_result) {
                     auto room = std::shared_ptr<Room>(room_result.value().release());
-                    
+
                     // Set the room's zone reference
                     room->set_zone_id(zone_id);
-                    
+
                     // Add room to world manager
                     rooms_[room->id()] = room;
                     stats_.rooms_loaded++;
-                    
+
                     // Add room ID to zone's room list
                     zone_shared->add_room(room->id());
-                    
+
                     logger->trace("Loaded room: {} ({}) in zone {}", room->name(), room->id(), zone_name);
                 } else {
                     logger->error("Failed to parse room in zone {}: {}", zone_name, room_result.error().message);
@@ -340,7 +340,7 @@ Result<void> WorldManager::load_zone_file(const std::string& filename) {
             }
         }
     }
-    
+
     // Parse embedded objects
     if (zone_json.contains("objects") && zone_json["objects"].is_array()) {
         for (const auto& object_json : zone_json["objects"]) {
@@ -361,7 +361,7 @@ Result<void> WorldManager::load_zone_file(const std::string& filename) {
             }
         }
     }
-    
+
     // Parse mobiles from the "mobs" array to create prototypes (but don't spawn them yet)
     if (zone_json.contains("mobs") && zone_json["mobs"].is_array()) {
         for (const auto& mob_json : zone_json["mobs"]) {
@@ -369,14 +369,14 @@ Result<void> WorldManager::load_zone_file(const std::string& filename) {
                 logger->warn("Mobile in zone {} missing id field", zone_name);
                 continue;
             }
-            
+
             EntityId mob_id{mob_json["id"].get<std::uint64_t>()};
-            
+
             // Check if we already have this mobile prototype
             if (mobiles_.find(mob_id) != mobiles_.end()) {
                 continue;
             }
-            
+
             // Create mobile prototype from JSON data
             auto mob_result = Mobile::from_json(mob_json);
             if (mob_result) {
@@ -389,23 +389,23 @@ Result<void> WorldManager::load_zone_file(const std::string& filename) {
                 logger->trace("Loaded mobile prototype: {} ({}) in zone {}",
                              mob->name(), mob_id, zone_name);
             } else {
-                logger->error("Failed to parse mobile {} in zone {}: {}", 
+                logger->error("Failed to parse mobile {} in zone {}: {}",
                              mob_id, zone_name, mob_result.error().message);
             }
         }
     }
-    
+
     // Note: Mobile spawning is now handled entirely by zone reset commands
     // The zone.commands.mob array will be processed by Zone::parse_nested_zone_commands()
     // and spawning will occur during zone->force_reset() in the main world loading loop
-    
+
     // Note: This method is called from the world strand - no mutex needed!
     // Zone already added above before processing embedded content
     stats_.zones_loaded++;
     has_unsaved_changes_.store(true);
-    
+
     logger->debug("Loaded zone: {} ({})", zone_name, zone_id);
-    
+
     return Success();
 }
 
@@ -415,20 +415,20 @@ Result<void> WorldManager::reload_zone(EntityId zone_id) {
     if (zone_it == zones_.end()) {
         return std::unexpected(Errors::NotFound("zone"));
     }
-    
+
     auto zone = zone_it->second;
     read_lock.unlock();
-    
+
     // Determine zone file path
     std::string filename = fmt::format("{}/{}.json", world_path_, zone_id.value());
-    
+
     auto result = zone->reload_from_file(filename);
     if (result) {
         has_unsaved_changes_.store(true);
         auto logger = Log::game();
         logger->info("Reloaded zone: {} ({})", zone->name(), zone_id);
     }
-    
+
     return result;
 }
 
@@ -439,7 +439,7 @@ Result<void> WorldManager::reload_all_zones() {
         zone_ids.push_back(id);
     }
     read_lock.unlock();
-    
+
     for (EntityId zone_id : zone_ids) {
         auto result = reload_zone(zone_id);
         if (!result) {
@@ -447,7 +447,7 @@ Result<void> WorldManager::reload_all_zones() {
             logger->error("Failed to reload zone {}: {}", zone_id, result.error().message);
         }
     }
-    
+
     return Success();
 }
 
@@ -473,25 +473,25 @@ Result<void> WorldManager::add_room(std::shared_ptr<Room> room) {
     if (!room) {
         return std::unexpected(Errors::InvalidArgument("room", "cannot be null"));
     }
-    
+
     std::unique_lock lock(world_mutex_);
     rooms_[room->id()] = room;
     has_unsaved_changes_.store(true);
-    
+
     auto logger = Log::game();
     logger->debug("Added room: {} ({})", room->name(), room->id());
-    
+
     return Success();
 }
 
 void WorldManager::remove_room(EntityId room_id) {
     std::unique_lock lock(world_mutex_);
-    
+
     auto it = rooms_.find(room_id);
     if (it != rooms_.end()) {
         auto logger = Log::game();
         logger->debug("Removing room: {} ({})", it->second->name(), room_id);
-        
+
         rooms_.erase(it);
         has_unsaved_changes_.store(true);
     }
@@ -500,26 +500,26 @@ void WorldManager::remove_room(EntityId room_id) {
 std::vector<std::shared_ptr<Room>> WorldManager::find_rooms_by_keyword(std::string_view keyword) const {
     std::shared_lock lock(world_mutex_);
     std::vector<std::shared_ptr<Room>> results;
-    
+
     for (const auto& [id, room] : rooms_) {
-        if (room && room->matches_keyword(keyword)) {
+        if (room && room->matches_target_string(keyword)) {
             results.push_back(room);
         }
     }
-    
+
     return results;
 }
 
 std::vector<std::shared_ptr<Room>> WorldManager::get_rooms_in_zone(EntityId zone_id) const {
     std::shared_lock lock(world_mutex_);
     std::vector<std::shared_ptr<Room>> results;
-    
+
     for (const auto& [id, room] : rooms_) {
         if (room && room->zone_id() == zone_id) {
             results.push_back(room);
         }
     }
-    
+
     return results;
 }
 
@@ -533,28 +533,28 @@ Result<void> WorldManager::add_zone(std::shared_ptr<Zone> zone) {
     if (!zone) {
         return std::unexpected(Errors::InvalidArgument("zone", "cannot be null"));
     }
-    
+
     auto zone_id = zone->id();
     auto zone_name = zone->name();
-    
+
     std::unique_lock lock(world_mutex_);
     zones_[zone_id] = std::move(zone);
     has_unsaved_changes_.store(true);
-    
+
     auto logger = Log::game();
     logger->debug("Added zone: {} ({})", zone_name, zone_id);
-    
+
     return Success();
 }
 
 void WorldManager::remove_zone(EntityId zone_id) {
     std::unique_lock lock(world_mutex_);
-    
+
     auto it = zones_.find(zone_id);
     if (it != zones_.end()) {
         auto logger = Log::game();
         logger->debug("Removing zone: {} ({})", it->second->name(), zone_id);
-        
+
         zones_.erase(it);
         has_unsaved_changes_.store(true);
     }
@@ -563,25 +563,25 @@ void WorldManager::remove_zone(EntityId zone_id) {
 std::vector<std::shared_ptr<Zone>> WorldManager::get_all_zones() const {
     std::shared_lock lock(world_mutex_);
     std::vector<std::shared_ptr<Zone>> results;
-    
+
     for (const auto& [id, zone] : zones_) {
         if (zone) {
             results.push_back(zone);
         }
     }
-    
+
     return results;
 }
 
 std::shared_ptr<Zone> WorldManager::find_zone_by_name(std::string_view name) const {
     std::shared_lock lock(world_mutex_);
-    
+
     for (const auto& [id, zone] : zones_) {
         if (zone && zone->name() == name) {
             return zone;
         }
     }
-    
+
     return nullptr;
 }
 
@@ -589,31 +589,31 @@ MovementResult WorldManager::move_actor(std::shared_ptr<Actor> actor, Direction 
     if (!actor) {
         return MovementResult("Actor is null");
     }
-    
+
     auto current_room = actor->current_room();
     if (!current_room) {
         return MovementResult("Actor not in valid room");
     }
-    
+
     auto exit = current_room->get_exit(direction);
     if (!exit) {
         return MovementResult("No exit in that direction");
     }
-    
+
     if (!exit->is_passable()) {
         return MovementResult("Exit is not passable");
     }
-    
+
     auto destination_room = get_room(exit->to_room);
     if (!destination_room) {
         return MovementResult("Destination room does not exist");
     }
-    
+
     auto movement_check = check_movement_restrictions(actor, current_room, destination_room, direction);
     if (!movement_check.success) {
         return movement_check;
     }
-    
+
     // Execute the movement
     current_room->remove_actor(actor->id());
     destination_room->add_actor(actor);
@@ -624,12 +624,12 @@ MovementResult WorldManager::move_actor(std::shared_ptr<Actor> actor, Direction 
     // Notify callbacks
     notify_room_exit(actor, current_room);
     notify_room_enter(actor, destination_room);
-    
+
     MovementResult result(true);
     result.from_room = current_room->id();
     result.to_room = destination_room->id();
     result.direction = direction;
-    
+
     auto logger = Log::movement();
     logger->debug("Actor {} moved {} from {} to {}",
                  actor->display_name(), direction, current_room->display_name(), destination_room->display_name());
@@ -662,20 +662,20 @@ MovementResult WorldManager::move_actor_to_room(std::shared_ptr<Actor> actor, En
     if (!actor) {
         return MovementResult("Actor is null");
     }
-    
+
     auto destination_room = get_room(room_id);
     if (!destination_room) {
         return MovementResult("Destination room does not exist");
     }
-    
+
     auto current_room = actor->current_room();
-    
+
     // Check movement restrictions
     auto movement_check = check_movement_restrictions(actor, current_room, destination_room, Direction::None);
     if (!movement_check.success) {
         return movement_check;
     }
-    
+
     // Execute the movement
     if (current_room) {
         current_room->remove_actor(actor->id());
@@ -688,15 +688,15 @@ MovementResult WorldManager::move_actor_to_room(std::shared_ptr<Actor> actor, En
     actor->move_to(destination_room);
 
     notify_room_enter(actor, destination_room);
-    
+
     MovementResult result(true);
     result.from_room = current_room ? current_room->id() : INVALID_ENTITY_ID;
     result.to_room = destination_room->id();
-    
+
     auto logger = Log::movement();
-    logger->debug("Actor {} teleported to {}", 
+    logger->debug("Actor {} teleported to {}",
                  actor->display_name(), destination_room->display_name());
-    
+
     return result;
 }
 
@@ -704,22 +704,22 @@ bool WorldManager::can_move_direction(std::shared_ptr<Actor> actor, Direction di
     if (!actor) {
         return false;
     }
-    
+
     auto current_room = actor->current_room();
     if (!current_room) {
         return false;
     }
-    
+
     auto exit = current_room->get_exit(direction);
     if (!exit || !exit->is_passable()) {
         return false;
     }
-    
+
     auto destination_room = get_room(exit->to_room);
     if (!destination_room) {
         return false;
     }
-    
+
     auto movement_check = check_movement_restrictions(actor, current_room, destination_room, direction);
     return movement_check.success;
 }
@@ -729,12 +729,12 @@ std::shared_ptr<Room> WorldManager::get_room_in_direction(EntityId from_room, Di
     if (!room) {
         return nullptr;
     }
-    
+
     auto exit = room->get_exit(direction);
     if (!exit) {
         return nullptr;
     }
-    
+
     return get_room(exit->to_room);
 }
 
@@ -746,13 +746,13 @@ Result<void> WorldManager::load_world_state() {
 void WorldManager::process_zone_resets() {
     std::shared_lock lock(world_mutex_);
     auto now = std::chrono::steady_clock::now();
-    
+
     // Check scheduled resets
     for (auto it = scheduled_resets_.begin(); it != scheduled_resets_.end();) {
         if (now >= it->second) {
             EntityId zone_id = it->first;
             it = scheduled_resets_.erase(it);
-            
+
             auto zone = get_zone(zone_id);
             if (zone) {
                 zone->force_reset();
@@ -762,7 +762,7 @@ void WorldManager::process_zone_resets() {
             ++it;
         }
     }
-    
+
     // Check natural zone resets
     for (const auto& [id, zone] : zones_) {
         if (zone && zone->needs_reset()) {
@@ -782,10 +782,10 @@ void WorldManager::force_zone_reset(EntityId zone_id) {
 
 void WorldManager::schedule_zone_reset(EntityId zone_id, std::chrono::seconds delay) {
     auto reset_time = std::chrono::steady_clock::now() + delay;
-    
+
     std::unique_lock lock(world_mutex_);
     scheduled_resets_[zone_id] = reset_time;
-    
+
     auto logger = Log::game();
     logger->debug("Scheduled zone {} reset in {}s", zone_id, delay.count());
 }
@@ -1002,33 +1002,33 @@ void WorldManager::update_statistics() {
 std::vector<std::shared_ptr<Zone>> WorldManager::find_zones_with_flag(ZoneFlag flag) const {
     std::shared_lock lock(world_mutex_);
     std::vector<std::shared_ptr<Zone>> results;
-    
+
     for (const auto& [id, zone] : zones_) {
         if (zone && zone->has_flag(flag)) {
             results.push_back(zone);
         }
     }
-    
+
     return results;
 }
 
 std::vector<std::shared_ptr<Room>> WorldManager::find_rooms_by_sector(SectorType sector) const {
     std::shared_lock lock(world_mutex_);
     std::vector<std::shared_ptr<Room>> results;
-    
+
     for (const auto& [id, room] : rooms_) {
         if (room && room->sector_type() == sector) {
             results.push_back(room);
         }
     }
-    
+
     return results;
 }
 
 std::vector<std::shared_ptr<Room>> WorldManager::find_rooms_in_level_range(int min_level, int max_level) const {
     std::shared_lock lock(world_mutex_);
     std::vector<std::shared_ptr<Room>> results;
-    
+
     for (const auto& [id, room] : rooms_) {
         if (room) {
             auto zone = get_zone(room->zone_id());
@@ -1037,58 +1037,58 @@ std::vector<std::shared_ptr<Room>> WorldManager::find_rooms_in_level_range(int m
             }
         }
     }
-    
+
     return results;
 }
 
-std::vector<Direction> WorldManager::find_path(EntityId from_room, EntityId to_room, 
+std::vector<Direction> WorldManager::find_path(EntityId from_room, EntityId to_room,
                                               std::shared_ptr<Actor> actor) const {
     // Simple breadth-first search pathfinding
     std::queue<EntityId> queue;
     std::unordered_map<EntityId, EntityId> came_from;
     std::unordered_map<EntityId, Direction> directions;
     std::unordered_set<EntityId> visited;
-    
+
     queue.push(from_room);
     visited.insert(from_room);
-    
+
     while (!queue.empty()) {
         EntityId current = queue.front();
         queue.pop();
-        
+
         if (current == to_room) {
             return reconstruct_path(came_from, directions, from_room, to_room);
         }
-        
+
         auto room = get_room(current);
         if (!room) {
             continue;
         }
-        
+
         auto available_exits = room->get_available_exits();
         for (Direction dir : available_exits) {
             auto exit = room->get_exit(dir);
             if (!exit || !exit->is_passable()) {
                 continue;
             }
-            
+
             EntityId next_room = exit->to_room;
             if (visited.contains(next_room)) {
                 continue;
             }
-            
+
             auto next_room_ptr = get_room(next_room);
             if (!next_room_ptr || !is_passable_for_actor(next_room_ptr, actor)) {
                 continue;
             }
-            
+
             visited.insert(next_room);
             came_from[next_room] = current;
             directions[next_room] = dir;
             queue.push(next_room);
         }
     }
-    
+
     return {}; // No path found
 }
 
@@ -1096,18 +1096,18 @@ int WorldManager::calculate_distance(EntityId from_room, EntityId to_room) const
     if (from_room == to_room) {
         return 0;
     }
-    
+
     auto path = find_path(from_room, to_room);
     return static_cast<int>(path.size());
 }
 
 void WorldManager::enable_file_watching(bool enabled) {
     file_watching_enabled_.store(enabled);
-    
+
     if (enabled) {
         update_file_timestamps();
     }
-    
+
     auto logger = Log::game();
     logger->info("File watching {}", enabled ? "enabled" : "disabled");
 }
@@ -1116,15 +1116,15 @@ void WorldManager::check_for_file_changes() {
     if (!file_watching_enabled_.load()) {
         return;
     }
-    
+
     auto changed_files = get_changed_files();
     if (changed_files.empty()) {
         return;
     }
-    
+
     auto logger = Log::game();
     logger->info("Detected {} changed world files", changed_files.size());
-    
+
     for (const auto& filename : changed_files) {
         logger->debug("File changed: {}", filename);
 
@@ -1178,13 +1178,13 @@ void WorldManager::check_for_file_changes() {
             }
         }
     }
-    
+
     update_file_timestamps();
 }
 
 std::string WorldManager::get_world_summary() const {
     std::shared_lock lock(world_mutex_);
-    
+
     return fmt::format(
         "World Summary:\n"
         "  Zones: {}\n"
@@ -1209,13 +1209,13 @@ std::string WorldManager::get_world_summary() const {
 std::vector<std::string> WorldManager::get_zone_list() const {
     std::shared_lock lock(world_mutex_);
     std::vector<std::string> zone_list;
-    
+
     for (const auto& [id, zone] : zones_) {
         if (zone) {
             zone_list.push_back(fmt::format("{}: {}", id, zone->name()));
         }
     }
-    
+
     std::sort(zone_list.begin(), zone_list.end());
     return zone_list;
 }
@@ -1223,10 +1223,10 @@ std::vector<std::string> WorldManager::get_zone_list() const {
 std::vector<std::string> WorldManager::get_orphaned_rooms() const {
     std::shared_lock lock(world_mutex_);
     std::vector<std::string> orphaned;
-    
+
     for (const auto& [id, room] : rooms_) {
         if (!room) continue;
-        
+
         bool found_in_zone = false;
         for (const auto& [zone_id, zone] : zones_) {
             if (zone && zone->contains_room(room->id())) {
@@ -1234,20 +1234,20 @@ std::vector<std::string> WorldManager::get_orphaned_rooms() const {
                 break;
             }
         }
-        
+
         if (!found_in_zone) {
             orphaned.push_back(fmt::format("{}: {}", id, room->name()));
         }
     }
-    
+
     return orphaned;
 }
 
 void WorldManager::dump_world_state(const std::string& filename) const {
     std::shared_lock lock(world_mutex_);
-    
+
     nlohmann::json dump;
-    
+
     // Dump zones
     nlohmann::json zones_json = nlohmann::json::array();
     for (const auto& [id, zone] : zones_) {
@@ -1256,7 +1256,7 @@ void WorldManager::dump_world_state(const std::string& filename) const {
         }
     }
     dump["zones"] = zones_json;
-    
+
     // Dump rooms
     nlohmann::json rooms_json = nlohmann::json::array();
     for (const auto& [id, room] : rooms_) {
@@ -1265,7 +1265,7 @@ void WorldManager::dump_world_state(const std::string& filename) const {
         }
     }
     dump["rooms"] = rooms_json;
-    
+
     // Dump statistics
     dump["statistics"] = {
         {"zones_loaded", stats_.zones_loaded},
@@ -1276,7 +1276,7 @@ void WorldManager::dump_world_state(const std::string& filename) const {
         {"load_time_ms", stats_.load_time.count()},
         {"save_time_ms", stats_.save_time.count()}
     };
-    
+
     std::ofstream file(filename);
     if (file.is_open()) {
         file << dump.dump(2);
@@ -1288,20 +1288,20 @@ Result<void> WorldManager::import_world_state(const std::string& filename) {
     if (!file.is_open()) {
         return std::unexpected(Errors::FileNotFound(filename));
     }
-    
+
     nlohmann::json dump;
     try {
         file >> dump;
     } catch (const nlohmann::json::exception& e) {
         return std::unexpected(Errors::ParseError("World state import", e.what()));
     }
-    
+
     std::unique_lock lock(world_mutex_);
-    
+
     // Clear existing data
     rooms_.clear();
     zones_.clear();
-    
+
     // Import zones
     if (dump.contains("zones") && dump["zones"].is_array()) {
         for (const auto& zone_json : dump["zones"]) {
@@ -1312,7 +1312,7 @@ Result<void> WorldManager::import_world_state(const std::string& filename) {
             }
         }
     }
-    
+
     // Import rooms
     if (dump.contains("rooms") && dump["rooms"].is_array()) {
         for (const auto& room_json : dump["rooms"]) {
@@ -1323,12 +1323,12 @@ Result<void> WorldManager::import_world_state(const std::string& filename) {
             }
         }
     }
-    
+
     has_unsaved_changes_.store(true);
-    
+
     auto logger = Log::game();
     logger->info("Imported world state from: {}", filename);
-    
+
     return Success();
 }
 
@@ -1338,9 +1338,9 @@ Result<void> WorldManager::load_zones_from_directory(const std::string& world_di
     if (!std::filesystem::exists(world_dir)) {
         return std::unexpected(Errors::FileNotFound(world_dir));
     }
-    
+
     auto zone_files = WorldUtils::get_zone_files(world_dir);
-    
+
     for (const auto& filename : zone_files) {
         std::string full_path = world_dir + "/" + filename;
         auto result = load_zone_file(full_path);
@@ -1350,7 +1350,7 @@ Result<void> WorldManager::load_zones_from_directory(const std::string& world_di
             stats_.failed_zone_loads++;
         }
     }
-    
+
     return Success();
 }
 
@@ -1734,21 +1734,21 @@ Result<void> WorldManager::load_rooms_from_directory(const std::string& /* room_
 
 void WorldManager::validate_room_exits(std::shared_ptr<Room> room, ValidationResult& result) const {
     auto exits = room->get_available_exits();
-    
+
     for (Direction dir : exits) {
         auto exit = room->get_exit(dir);
         if (!exit) continue;
-        
+
         if (!exit->to_room.is_valid()) {
             result.missing_exits++;
-            result.add_error(fmt::format("Room {} has invalid exit {} destination", 
+            result.add_error(fmt::format("Room {} has invalid exit {} destination",
                                        room->id(), dir));
             continue;
         }
-        
+
         if (!get_room(exit->to_room)) {
             result.missing_exits++;
-            result.add_error(fmt::format("Room {} exit {} points to non-existent room {}", 
+            result.add_error(fmt::format("Room {} exit {} points to non-existent room {}",
                                        room->id(), dir, exit->to_room));
         }
     }
@@ -1757,14 +1757,14 @@ void WorldManager::validate_room_exits(std::shared_ptr<Room> room, ValidationRes
 void WorldManager::validate_zone_integrity(std::shared_ptr<Zone> zone, ValidationResult& result) const {
     auto zone_result = zone->validate();
     if (!zone_result) {
-        result.add_error(fmt::format("Zone {} validation failed: {}", 
+        result.add_error(fmt::format("Zone {} validation failed: {}",
                                    zone->id(), zone_result.error().message));
     }
-    
+
     // Check if zone rooms exist
     for (EntityId room_id : zone->rooms()) {
         if (!get_room(room_id)) {
-            result.add_error(fmt::format("Zone {} references non-existent room {}", 
+            result.add_error(fmt::format("Zone {} references non-existent room {}",
                                        zone->id(), room_id));
         }
     }
@@ -2059,7 +2059,7 @@ bool WorldManager::check_and_handle_object_falling(std::shared_ptr<Object> objec
 
 void WorldManager::update_file_timestamps() {
     file_timestamps_.clear();
-    
+
     if (std::filesystem::exists(world_path_)) {
         for (const auto& entry : std::filesystem::directory_iterator(world_path_)) {
             if (entry.is_regular_file() && entry.path().extension() == ".json") {
@@ -2071,25 +2071,25 @@ void WorldManager::update_file_timestamps() {
 
 std::vector<std::string> WorldManager::get_changed_files() {
     std::vector<std::string> changed_files;
-    
+
     if (!std::filesystem::exists(world_path_)) {
         return changed_files;
     }
-    
+
     for (const auto& entry : std::filesystem::directory_iterator(world_path_)) {
         if (!entry.is_regular_file() || entry.path().extension() != ".json") {
             continue;
         }
-        
+
         std::string filepath = entry.path().string();
         auto current_time = entry.last_write_time();
-        
+
         auto it = file_timestamps_.find(filepath);
         if (it == file_timestamps_.end() || it->second != current_time) {
             changed_files.push_back(filepath);
         }
     }
-    
+
     return changed_files;
 }
 
@@ -2097,26 +2097,26 @@ std::vector<Direction> WorldManager::reconstruct_path(
     const std::unordered_map<EntityId, EntityId>& came_from,
     const std::unordered_map<EntityId, Direction>& directions,
     EntityId start, EntityId goal) const {
-    
+
     std::vector<Direction> path;
     EntityId current = goal;
-    
+
     while (current != start) {
         auto dir_it = directions.find(current);
         if (dir_it == directions.end()) {
             break;
         }
-        
+
         path.push_back(dir_it->second);
-        
+
         auto came_it = came_from.find(current);
         if (came_it == came_from.end()) {
             break;
         }
-        
+
         current = came_it->second;
     }
-    
+
     std::reverse(path.begin(), path.end());
     return path;
 }
@@ -2246,20 +2246,20 @@ Result<void> WorldManager::spawn_mobile_in_zone(Mobile* prototype, EntityId zone
     if (!prototype) {
         return std::unexpected(Errors::InvalidArgument("prototype", "cannot be null"));
     }
-    
+
     auto zone = get_zone(zone_id);
     if (!zone) {
         return std::unexpected(Errors::NotFound("zone"));
     }
-    
+
     auto logger = Log::game();
-    
+
     // Create a new mobile instance from the prototype
     auto new_mobile_result = Mobile::create(prototype->id(), prototype->name(), prototype->stats().level);
     if (!new_mobile_result) {
         return std::unexpected(new_mobile_result.error());
     }
-    
+
     auto new_mobile = std::move(new_mobile_result.value());
 
     // Copy stats and properties from prototype
@@ -2326,10 +2326,10 @@ Result<void> WorldManager::spawn_mobile_in_zone(Mobile* prototype, EntityId zone
         logger->warn("No rooms available in zone {} for spawning mobile {}", zone_id, prototype->name());
         return std::unexpected(Errors::InvalidState("No rooms in zone"));
     }
-    
+
     // For the test zone, spawn specific mobs in specific rooms
     std::shared_ptr<Room> spawn_room = nullptr;
-    
+
     if (prototype->name() == "a practice dummy") {
         // Spawn practice dummy in training room
         spawn_room = get_room(EntityId{TEST_TRAINING_ROOM_ID});
@@ -2337,21 +2337,21 @@ Result<void> WorldManager::spawn_mobile_in_zone(Mobile* prototype, EntityId zone
         // Spawn training guard in starting room
         spawn_room = get_room(EntityId{TEST_STARTING_ROOM_ID});
     }
-    
+
     // Fallback to first room if specific placement didn't work
     if (!spawn_room) {
         spawn_room = zone_rooms[0];
     }
-    
+
     // Place the mobile in the room
     auto actor_ptr = std::shared_ptr<Actor>(new_mobile.release());
     auto move_result = move_actor_to_room(actor_ptr, spawn_room->id());
     if (!move_result.success) {
-        logger->error("Failed to place mobile {} in room {}: {}", 
+        logger->error("Failed to place mobile {} in room {}: {}",
                      prototype->name(), spawn_room->id(), move_result.failure_reason);
         return std::unexpected(Errors::InvalidState(move_result.failure_reason));
     }
-    
+
     logger->debug("Spawned mobile '{}' in room '{}' ({})",
                 prototype->name(), spawn_room->name(), spawn_room->id());
 
@@ -2360,22 +2360,22 @@ Result<void> WorldManager::spawn_mobile_in_zone(Mobile* prototype, EntityId zone
 
 void WorldManager::setup_zone_callbacks(std::shared_ptr<Zone> zone) {
     if (!zone) return;
-    
+
     // Set up mobile spawning callback
     zone->set_spawn_mobile_callback([this](EntityId mobile_id, EntityId room_id) -> std::shared_ptr<Mobile> {
         return spawn_mobile_for_zone(mobile_id, room_id);
     });
-    
+
     // Set up object spawning callback
     zone->set_spawn_object_callback([this](EntityId object_id, EntityId room_id) -> std::shared_ptr<Object> {
         return spawn_object_for_zone(object_id, room_id);
     });
-    
+
     // Set up room lookup callback
     zone->set_get_room_callback([this](EntityId room_id) -> std::shared_ptr<Room> {
         return get_room(room_id);
     });
-    
+
     // Set up object removal callback
     zone->set_remove_object_callback([this](EntityId object_id, EntityId room_id) -> bool {
         auto room = get_room(room_id);
@@ -2384,7 +2384,7 @@ void WorldManager::setup_zone_callbacks(std::shared_ptr<Zone> zone) {
         }
         return room->remove_object(object_id);
     });
-    
+
     // Set up zone mobile cleanup callback
     zone->set_cleanup_zone_mobiles_callback([this](EntityId zone_id) {
         cleanup_zone_mobiles(zone_id);
@@ -2393,14 +2393,14 @@ void WorldManager::setup_zone_callbacks(std::shared_ptr<Zone> zone) {
 
 std::shared_ptr<Mobile> WorldManager::spawn_mobile_for_zone(EntityId mobile_id, EntityId room_id) {
     auto logger = Log::game();
-    
+
     // Find mobile prototype
     auto mobile_it = mobiles_.find(mobile_id);
     if (mobile_it == mobiles_.end()) {
         logger->error("Cannot spawn mobile {} - prototype not found", mobile_id);
         return nullptr;
     }
-    
+
     Mobile* prototype = mobile_it->second.get();
 
     // Create new mobile instance from prototype
@@ -2409,9 +2409,9 @@ std::shared_ptr<Mobile> WorldManager::spawn_mobile_for_zone(EntityId mobile_id, 
         logger->error("Failed to create mobile instance: {}", new_mobile_result.error().message);
         return nullptr;
     }
-    
+
     auto new_mobile = std::move(new_mobile_result.value());
-    
+
     // Copy stats and properties from prototype
     new_mobile->set_keywords(prototype->keywords());
     new_mobile->set_short_description(prototype->short_description());
@@ -2618,24 +2618,24 @@ std::shared_ptr<Object> WorldManager::spawn_object_for_zone(EntityId object_id, 
     if (is_equipment_request) {
         // Decode the mobile ID from the packed local_id using helper functions
         EntityId mobile_id = unpack_entity_id(packed_mobile);
-        
+
         // Use efficient O(1) lookup for the mobile
         std::shared_ptr<Mobile> target_mobile = find_spawned_mobile(mobile_id);
-        
+
         if (!target_mobile) {
             logger->warn("Cannot equip object '{}' ({}) - mobile {} not found",
                         prototype->short_description(), object_id, mobile_id);
             return nullptr;
         }
-        
+
         // Convert equipment slot number to EquipSlot enum
         EquipSlot equip_slot = static_cast<EquipSlot>(potential_slot);
-        
+
         auto shared_object = std::shared_ptr<Object>(new_object.release());
-        
+
         // Set the correct equip slot on the object before equipping
         shared_object->set_equip_slot(equip_slot);
-        
+
         // Try to equip the item on the mobile
         auto equip_result = target_mobile->equipment().equip_item(shared_object);
         if (!equip_result) {
@@ -2652,7 +2652,7 @@ std::shared_ptr<Object> WorldManager::spawn_object_for_zone(EntityId object_id, 
                 return nullptr;
             }
         }
-        
+
         logger->trace("Equipped '{}' ({}) on mobile '{}' in slot {}",
                      prototype->short_description(), object_id, target_mobile->display_name(),
                      magic_enum::enum_name(equip_slot));
@@ -2783,15 +2783,15 @@ Result<void> WorldManager::spawn_mobile_in_specific_room(Mobile* prototype, Enti
     if (!prototype) {
         return std::unexpected(Errors::InvalidArgument("prototype", "cannot be null"));
     }
-    
+
     auto logger = Log::game();
-    
+
     // Create a new mobile instance from the prototype
     auto new_mobile_result = Mobile::create(prototype->id(), prototype->name(), prototype->stats().level);
     if (!new_mobile_result) {
         return std::unexpected(new_mobile_result.error());
     }
-    
+
     auto new_mobile = std::move(new_mobile_result.value());
 
     // Copy stats and properties from prototype
@@ -2858,15 +2858,15 @@ Result<void> WorldManager::spawn_mobile_in_specific_room(Mobile* prototype, Enti
         logger->error("Cannot spawn mobile {} - room {} not found", prototype->name(), room_id);
         return std::unexpected(Errors::NotFound("room"));
     }
-    
+
     auto actor_ptr = std::shared_ptr<Actor>(new_mobile.release());
     auto move_result = move_actor_to_room(actor_ptr, room_id);
     if (!move_result.success) {
-        logger->error("Failed to place mobile {} in room {}: {}", 
+        logger->error("Failed to place mobile {} in room {}: {}",
                      prototype->name(), spawn_room->id(), move_result.failure_reason);
         return std::unexpected(Errors::InvalidState(move_result.failure_reason));
     }
-    
+
     // Register the spawned mobile for efficient lookups
     auto mobile_ptr = std::static_pointer_cast<Mobile>(actor_ptr);
     register_spawned_mobile(mobile_ptr);
@@ -2883,10 +2883,10 @@ Result<void> WorldManager::spawn_mobile_in_specific_room(Mobile* prototype, Enti
 // Mobile instance tracking for efficient lookups
 void WorldManager::register_spawned_mobile(std::shared_ptr<Mobile> mobile) {
     if (!mobile) return;
-    
+
     std::lock_guard<std::shared_mutex> lock(world_mutex_);
     spawned_mobiles_[mobile->id()] = mobile;
-    
+
     auto logger = Log::game();
     logger->debug("Registered spawned mobile {} ({})", mobile->display_name(), mobile->id());
 }
@@ -2910,27 +2910,27 @@ std::shared_ptr<Mobile> WorldManager::find_spawned_mobile(EntityId mobile_id) co
 void WorldManager::cleanup_zone_mobiles(EntityId zone_id) {
     auto logger = Log::game();
     logger->debug("Cleaning up mobiles in zone {}", zone_id);
-    
+
     auto zone_it = zones_.find(zone_id);
     if (zone_it == zones_.end()) {
         logger->warn("Zone {} not found during mobile cleanup", zone_id);
         return;
     }
-    
+
     auto zone = zone_it->second;
     std::vector<EntityId> mobiles_to_remove;
-    
+
     // Find all mobiles in rooms belonging to this zone
     for (EntityId room_id : zone->rooms()) {
         auto room_it = rooms_.find(room_id);
         if (room_it == rooms_.end()) {
             continue; // Room not found, skip
         }
-        
+
         auto room = room_it->second;
         // Copy actor IDs since we'll be modifying the collection
-        auto actors = room->contents().actors;  
-        
+        auto actors = room->contents().actors;
+
         for (const auto& actor : actors) {
             // Check if this actor is a mobile (not a player)
             auto mobile = std::dynamic_pointer_cast<Mobile>(actor);
@@ -2942,7 +2942,7 @@ void WorldManager::cleanup_zone_mobiles(EntityId zone_id) {
             }
         }
     }
-    
+
     // Unregister mobiles from tracking system
     {
         std::lock_guard<std::shared_mutex> lock(world_mutex_);
@@ -2954,7 +2954,7 @@ void WorldManager::cleanup_zone_mobiles(EntityId zone_id) {
             }
         }
     }
-    
+
     if (!mobiles_to_remove.empty()) {
         logger->info("Cleaned up {} mobiles from zone {}", mobiles_to_remove.size(), zone_id);
     }
@@ -2976,14 +2976,14 @@ void WorldManager::update_weather_system(std::chrono::minutes elapsed) {
 
 void WorldManager::initialize_weather_callbacks() {
     auto logger = Log::game();
-    
+
     // Initialize weather system
     auto weather_result = WeatherSystem::initialize();
     if (!weather_result) {
         logger->error("Failed to initialize weather system: {}", weather_result.error().message);
         return;
     }
-    
+
     // Set up weather change callback for logging and zone effects
     Weather().set_weather_change_callback([logger](EntityId zone_id, const WeatherState& old_state, const WeatherState& new_state) {
         if (zone_id == INVALID_ENTITY_ID) {
@@ -2992,13 +2992,13 @@ void WorldManager::initialize_weather_callbacks() {
             logger->info("Zone {} weather changed from {} to {}", zone_id, old_state.get_summary(), new_state.get_summary());
         }
     });
-    
+
     // Initialize weather configs for loaded zones
     for (const auto& [zone_id, zone] : zones_) {
         if (!zone) continue;
-        
+
         WeatherConfig config;
-        
+
         // Set weather pattern based on zone characteristics
         if (zone->is_underground()) {
             config.pattern = WeatherPattern::Stable;
@@ -3010,10 +3010,10 @@ void WorldManager::initialize_weather_callbacks() {
         } else if (zone->is_quest_zone()) {
             config.pattern = WeatherPattern::Variable;
         }
-        
+
         Weather().set_zone_weather_config(zone_id, config);
     }
-    
+
     logger->info("Weather system integration initialized");
 }
 
@@ -3216,74 +3216,74 @@ std::shared_ptr<MobileTemplate> WorldManager::get_mobile_template(EntityId id) c
 namespace WorldUtils {
     std::vector<std::string> get_zone_files(const std::string& world_dir) {
         std::vector<std::string> zone_files;
-        
+
         if (!std::filesystem::exists(world_dir)) {
             return zone_files;
         }
-        
+
         for (const auto& entry : std::filesystem::directory_iterator(world_dir)) {
             if (entry.is_regular_file() && entry.path().extension() == ".json") {
                 zone_files.push_back(entry.path().filename().string());
             }
         }
-        
+
         std::sort(zone_files.begin(), zone_files.end());
         return zone_files;
     }
-    
+
     std::vector<std::string> get_room_files(const std::string& room_dir) {
         std::vector<std::string> room_files;
-        
+
         if (!std::filesystem::exists(room_dir)) {
             return room_files;
         }
-        
+
         for (const auto& entry : std::filesystem::directory_iterator(room_dir)) {
             if (entry.is_regular_file() && entry.path().extension() == ".wld") {
                 room_files.push_back(entry.path().filename().string());
             }
         }
-        
+
         std::sort(room_files.begin(), room_files.end());
         return room_files;
     }
-    
+
     Result<void> backup_world_data(const std::string& world_path, const std::string& backup_path) {
         try {
             if (std::filesystem::exists(backup_path)) {
                 std::filesystem::remove_all(backup_path);
             }
-            
-            std::filesystem::copy(world_path, backup_path, 
+
+            std::filesystem::copy(world_path, backup_path,
                                 std::filesystem::copy_options::recursive);
-            
+
             return Success();
         } catch (const std::filesystem::filesystem_error& e) {
             return std::unexpected(Errors::FileAccessError(e.what()));
         }
     }
-    
+
     Result<void> restore_world_data(const std::string& backup_path, const std::string& world_path) {
         try {
             if (std::filesystem::exists(world_path)) {
                 std::filesystem::remove_all(world_path);
             }
-            
+
             std::filesystem::copy(backup_path, world_path,
                                 std::filesystem::copy_options::recursive);
-            
+
             return Success();
         } catch (const std::filesystem::filesystem_error& e) {
             return std::unexpected(Errors::FileAccessError(e.what()));
         }
     }
-    
+
     std::unordered_map<std::string, int> calculate_world_metrics(const WorldManager& world) {
         std::unordered_map<std::string, int> metrics;
-        
+
         metrics["total_zones"] = static_cast<int>(world.zone_count());
         metrics["total_rooms"] = static_cast<int>(world.room_count());
-        
+
         // Count rooms by sector type
         for (size_t i = 0; i < magic_enum::enum_count<SectorType>(); ++i) {
             auto sector = static_cast<SectorType>(i);
@@ -3291,7 +3291,7 @@ namespace WorldUtils {
             std::string key = fmt::format("rooms_{}", magic_enum::enum_name(sector));
             metrics[key] = static_cast<int>(rooms.size());
         }
-        
+
         // Count zones by flag
         for (size_t i = 0; i < magic_enum::enum_count<ZoneFlag>(); ++i) {
             auto flag = static_cast<ZoneFlag>(i);
@@ -3299,26 +3299,26 @@ namespace WorldUtils {
             std::string key = fmt::format("zones_{}", magic_enum::enum_name(flag));
             metrics[key] = static_cast<int>(zones.size());
         }
-        
+
         return metrics;
     }
-    
-    Result<void> export_world(const WorldManager& world, const std::string& filename, 
+
+    Result<void> export_world(const WorldManager& world, const std::string& filename,
                              std::string_view format) {
         if (format == "json") {
             world.dump_world_state(filename);
             return Success();
         }
-        
+
         return std::unexpected(Errors::NotImplemented(fmt::format("Export format: {}", format)));
     }
-    
+
     Result<void> import_world(WorldManager& world, const std::string& filename,
                              std::string_view format) {
         if (format == "json") {
             return world.import_world_state(filename);
         }
-        
+
         return std::unexpected(Errors::NotImplemented(fmt::format("Import format: {}", format)));
     }
 }

--- a/tests/unit/test_entity_utils.cpp
+++ b/tests/unit/test_entity_utils.cpp
@@ -1,0 +1,54 @@
+#include "../src/core/entity.hpp"
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+static const std::set<std::string> test_keywords{
+    "silly",
+    "little",
+    "test",
+    "case",
+};
+
+TEST_CASE("Entity Utils", "matches_target_string") {
+    SECTION("Prefix match with single keyword") {
+        REQUIRE(EntityUtils::matches_target_string(test_keywords, "silly") == true);
+        REQUIRE(EntityUtils::matches_target_string(test_keywords, "little") == true);
+        REQUIRE(EntityUtils::matches_target_string(test_keywords, "test") == true);
+        REQUIRE(EntityUtils::matches_target_string(test_keywords, "case") == true);
+        REQUIRE(EntityUtils::matches_target_string(test_keywords, "lit") == true);
+        REQUIRE(EntityUtils::matches_target_string(test_keywords, "zany") == false);
+    }
+
+    SECTION("Prefix match with multiple keywords") {
+        REQUIRE(EntityUtils::matches_target_string(test_keywords, "silly-little") == true);
+        REQUIRE(EntityUtils::matches_target_string(test_keywords, "case-little") == true);
+        REQUIRE(EntityUtils::matches_target_string(test_keywords, "lit-cas") == true);
+        REQUIRE(EntityUtils::matches_target_string(test_keywords, "cas-lit") == true);
+        REQUIRE(EntityUtils::matches_target_string(test_keywords, "zany-something") == false);
+    }
+}
+
+TEST_CASE("Entity Utils", "normalize_keyword") {
+    SECTION("Normalize input") {
+        std::string normalized = EntityUtils::normalize_keyword("Mixed Case  with strange--parts");
+        REQUIRE(normalized == "mixed case with strange-parts");
+    }
+}
+
+TEST_CASE("Entity Utils", "parse_target_string") {
+    SECTION("Normalize input") {
+        auto tokens = EntityUtils::parse_target_string("--Mixed--funky-sTring");
+        REQUIRE(tokens.size() == 3);
+        REQUIRE(tokens.contains("mixed"));
+        REQUIRE(tokens.contains("funky"));
+        REQUIRE(tokens.contains("string"));
+    }
+
+    SECTION("Deduplicate keywords") {
+        auto tokens = EntityUtils::parse_target_string("run-forrest-run");
+        REQUIRE(tokens.size() == 2);
+        REQUIRE(tokens.contains("run"));
+        REQUIRE(tokens.contains("forrest"));
+    }
+}

--- a/tests/unit/test_entity_utils.cpp
+++ b/tests/unit/test_entity_utils.cpp
@@ -1,7 +1,12 @@
-#include "../src/core/entity.hpp"
-
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+#include <memory>
+#include <string>
+
+#include "../src/core/entity.hpp"
+#include "../src/core/object.hpp"
+#include "../src/core/actor.hpp"
+#include "../src/world/room.hpp"
 
 static const std::set<std::string> test_keywords{
     "silly",
@@ -9,8 +14,9 @@ static const std::set<std::string> test_keywords{
     "test",
     "case",
 };
+static const std::vector<std::string> test_keywords_vec(test_keywords.begin(), test_keywords.end());
 
-TEST_CASE("Entity Utils", "matches_target_string") {
+TEST_CASE("Entity Utils - matches_target_string", "[entity][utils]") {
     SECTION("Prefix match with single keyword") {
         REQUIRE(EntityUtils::matches_target_string(test_keywords, "silly") == true);
         REQUIRE(EntityUtils::matches_target_string(test_keywords, "little") == true);
@@ -29,14 +35,14 @@ TEST_CASE("Entity Utils", "matches_target_string") {
     }
 }
 
-TEST_CASE("Entity Utils", "normalize_keyword") {
+TEST_CASE("Entity Utils - normalize_keyword", "[entity][utils]") {
     SECTION("Normalize input") {
         std::string normalized = EntityUtils::normalize_keyword("Mixed Case  with strange--parts");
         REQUIRE(normalized == "mixed case with strange-parts");
     }
 }
 
-TEST_CASE("Entity Utils", "parse_target_string") {
+TEST_CASE("Entity Utils - parse_target_string", "[entity][utils]") {
     SECTION("Normalize input") {
         auto tokens = EntityUtils::parse_target_string("--Mixed--funky-sTring");
         REQUIRE(tokens.size() == 3);
@@ -50,5 +56,76 @@ TEST_CASE("Entity Utils", "parse_target_string") {
         REQUIRE(tokens.size() == 2);
         REQUIRE(tokens.contains("run"));
         REQUIRE(tokens.contains("forrest"));
+    }
+}
+
+TEST_CASE("Entity - matches_all_keywords", "[entity][utils]") {
+    SECTION("Prefix match with single keyword") {
+        auto obj = Object::create(EntityId{1001}, "object", ObjectType::Other).value();
+        obj->set_keywords(test_keywords_vec);
+
+        REQUIRE(obj->matches_all_keywords(std::vector<std::string>{ "obj" }) == true);
+        REQUIRE(obj->matches_all_keywords(std::vector<std::string>{ "silly" }) == true);
+        REQUIRE(obj->matches_all_keywords(std::vector<std::string>{ "little" }) == true);
+        REQUIRE(obj->matches_all_keywords(std::vector<std::string>{ "test" }) == true);
+        REQUIRE(obj->matches_all_keywords(std::vector<std::string>{ "case" }) == true);
+        REQUIRE(obj->matches_all_keywords(std::vector<std::string>{ "lit" }) == true);
+        REQUIRE(obj->matches_all_keywords(std::vector<std::string>{ "zany" }) == false);
+    }
+
+    SECTION("Prefix match with multiple keywords") {
+        auto obj = Object::create(EntityId{1001}, "object", ObjectType::Other).value();
+        obj->set_keywords(test_keywords_vec);
+
+        REQUIRE(obj->matches_all_keywords(std::vector<std::string>{ "obj", "little" }) == true);
+        REQUIRE(obj->matches_all_keywords(std::vector<std::string>{ "silly", "little" }) == true);
+        REQUIRE(obj->matches_all_keywords(std::vector<std::string>{ "case", "little" }) == true);
+        REQUIRE(obj->matches_all_keywords(std::vector<std::string>{ "lit", "cas" }) == true);
+        REQUIRE(obj->matches_all_keywords(std::vector<std::string>{ "cas", "lit" }) == true);
+        REQUIRE(obj->matches_all_keywords(std::vector<std::string>{ "zany", "something" }) == false);
+    }
+
+    SECTION("Match liquid in drink container") {
+        auto obj = Object::create(EntityId{1001}, "beverage", ObjectType::Other).value();
+        obj->set_keywords(test_keywords_vec);
+
+        LiquidInfo liquid;
+        liquid.liquid_type = "wine";
+        liquid.capacity = 10;
+        liquid.remaining = 10;
+        liquid.identified = true;
+
+        // can target a drink container by an identified liquid if it isn't empty
+        obj->set_liquid_info(liquid);
+        REQUIRE(obj->matches_all_keywords(std::vector<std::string>{ "beverage" }) == true);
+        REQUIRE(obj->matches_all_keywords(std::vector<std::string>{ "wine" }) == true);
+        REQUIRE(obj->matches_all_keywords(std::vector<std::string>{ "win", "bev" }) == true);
+        REQUIRE(obj->matches_all_keywords(std::vector<std::string>{ "water" }) == false);
+
+        // empty container can't be targeted by liquid
+        liquid.remaining = 0;
+        obj->set_liquid_info(liquid);
+        REQUIRE(obj->matches_all_keywords(std::vector<std::string>{ "beverage" }) == true);
+        REQUIRE(obj->matches_all_keywords(std::vector<std::string>{ "wine" }) == false);
+        REQUIRE(obj->matches_all_keywords(std::vector<std::string>{ "win", "bev" }) == false);
+        REQUIRE(obj->matches_all_keywords(std::vector<std::string>{ "water" }) == false);
+
+        // unidentified liquid can't be targeted
+        liquid.remaining = 10;
+        liquid.identified = false;
+        obj->set_liquid_info(liquid);
+        REQUIRE(obj->matches_all_keywords(std::vector<std::string>{ "beverage" }) == true);
+        REQUIRE(obj->matches_all_keywords(std::vector<std::string>{ "wine" }) == false);
+        REQUIRE(obj->matches_all_keywords(std::vector<std::string>{ "win", "bev" }) == false);
+        REQUIRE(obj->matches_all_keywords(std::vector<std::string>{ "water" }) == false);
+
+        // undefined liquid can't be targeted
+        liquid.liquid_type.clear();
+        liquid.identified = true;
+        obj->set_liquid_info(liquid);
+        REQUIRE(obj->matches_all_keywords(std::vector<std::string>{ "beverage" }) == true);
+        REQUIRE(obj->matches_all_keywords(std::vector<std::string>{ "wine" }) == false);
+        REQUIRE(obj->matches_all_keywords(std::vector<std::string>{ "win", "bev" }) == false);
+        REQUIRE(obj->matches_all_keywords(std::vector<std::string>{ "water" }) == false);
     }
 }

--- a/tests/unit/test_object_interactions.cpp
+++ b/tests/unit/test_object_interactions.cpp
@@ -8,135 +8,135 @@
 #include "../src/world/room.hpp"
 
 TEST_CASE("Object Interaction Integration Test", "[integration][objects][commands]") {
-    
+
     // Create a test room
     auto room_result = Room::create(EntityId{1001}, "Test Room");
     REQUIRE(room_result.has_value());
     auto room = std::shared_ptr<Room>(room_result.value().release());
     room->set_short_description("a test room");
     room->set_description("This is a test room for object interactions.");
-    
+
     // Create a test player
     auto player_result = Player::create(EntityId{2001}, "TestPlayer");
     REQUIRE(player_result.has_value());
     auto player = std::shared_ptr<Player>(player_result.value().release());
     player->set_current_room(room);
-    
+
     // Create test objects with different keyword patterns
     auto bread = Object::create(EntityId{3010}, "bread loaf food", ObjectType::Food);
     REQUIRE(bread.has_value());
     (*bread)->set_short_description("some bread");
     (*bread)->set_description("A fresh loaf of bread with a golden crust.");
-    
+
     auto sword = Object::create(EntityId{3020}, "sword blade weapon", ObjectType::Weapon);
     REQUIRE(sword.has_value());
     (*sword)->set_short_description("a sharp sword");
     (*sword)->set_description("A well-forged steel sword with a gleaming blade.");
-    
+
     // Add objects to the room
     room->add_object(std::shared_ptr<Object>(bread.value().release()));
     room->add_object(std::shared_ptr<Object>(sword.value().release()));
     room->add_actor(player);
-    
+
     SECTION("Look command shows objects with short descriptions") {
         // Simulate 'look' command
         std::ostringstream output;
-        
+
         // Test that we can see objects in room with their short descriptions
         auto room_objects = room->contents().objects;
         REQUIRE(room_objects.size() == 2);
-        
+
         // Verify bread object
         bool found_bread = false;
         bool found_sword = false;
-        
+
         for (const auto& obj : room_objects) {
             if (obj->id() == EntityId{3010}) {
                 found_bread = true;
                 REQUIRE(obj->short_description() == "some bread");
                 REQUIRE(obj->name() == "bread loaf food");
-                REQUIRE(obj->matches_keyword("bread"));
-                REQUIRE(obj->matches_keyword("loaf"));
-                REQUIRE(obj->matches_keyword("food"));
+                REQUIRE(obj->matches_target_string("bread"));
+                REQUIRE(obj->matches_target_string("loaf"));
+                REQUIRE(obj->matches_target_string("food"));
             }
             if (obj->id() == EntityId{3020}) {
                 found_sword = true;
                 REQUIRE(obj->short_description() == "a sharp sword");
                 REQUIRE(obj->name() == "sword blade weapon");
-                REQUIRE(obj->matches_keyword("sword"));
-                REQUIRE(obj->matches_keyword("blade"));
-                REQUIRE(obj->matches_keyword("weapon"));
+                REQUIRE(obj->matches_target_string("sword"));
+                REQUIRE(obj->matches_target_string("blade"));
+                REQUIRE(obj->matches_target_string("weapon"));
             }
         }
-        
+
         REQUIRE(found_bread);
         REQUIRE(found_sword);
     }
-    
+
     SECTION("Object keyword matching works correctly") {
         auto room_objects = room->contents().objects;
-        
+
         // Test bread keywords
         auto bread_obj = room_objects[0]->id() == EntityId{3010} ? room_objects[0] : room_objects[1];
-        REQUIRE(bread_obj->matches_keyword("bread"));
-        REQUIRE(bread_obj->matches_keyword("loaf"));
-        REQUIRE(bread_obj->matches_keyword("food"));
-        REQUIRE_FALSE(bread_obj->matches_keyword("sword"));
-        REQUIRE_FALSE(bread_obj->matches_keyword("nonexistent"));
-        
+        REQUIRE(bread_obj->matches_target_string("bread"));
+        REQUIRE(bread_obj->matches_target_string("loaf"));
+        REQUIRE(bread_obj->matches_target_string("food"));
+        REQUIRE_FALSE(bread_obj->matches_target_string("sword"));
+        REQUIRE_FALSE(bread_obj->matches_target_string("nonexistent"));
+
         // Test case insensitive matching
-        REQUIRE(bread_obj->matches_keyword("BREAD"));
-        REQUIRE(bread_obj->matches_keyword("Loaf"));
-        REQUIRE(bread_obj->matches_keyword("FooD"));
+        REQUIRE(bread_obj->matches_target_string("BREAD"));
+        REQUIRE(bread_obj->matches_target_string("Loaf"));
+        REQUIRE(bread_obj->matches_target_string("FooD"));
     }
-    
+
     SECTION("Take and drop commands work with keywords") {
         // Verify objects start in room
         REQUIRE(room->contents().objects.size() == 2);
         REQUIRE(player->inventory().empty());
-        
+
         // Test finding objects by different keywords using room methods
-        
+
         // Find bread using "bread" keyword
         auto bread_results = room->find_objects_by_keyword("bread");
         REQUIRE(bread_results.size() == 1);
         REQUIRE(bread_results[0]->id() == EntityId{3010});
-        
+
         // Find sword using "blade" keyword
         auto blade_results = room->find_objects_by_keyword("blade");
         REQUIRE(blade_results.size() == 1);
         REQUIRE(blade_results[0]->id() == EntityId{3020});
-        
+
         // Test finding using "weapon" keyword (should find sword)
         auto weapon_results = room->find_objects_by_keyword("weapon");
         REQUIRE(weapon_results.size() == 1);
         REQUIRE(weapon_results[0]->id() == EntityId{3020});
-        
+
         // Test finding using "food" keyword (should find bread)
         auto food_results = room->find_objects_by_keyword("food");
         REQUIRE(food_results.size() == 1);
         REQUIRE(food_results[0]->id() == EntityId{3010});
-        
+
         // Test non-existent keyword
         auto nonexistent_results = room->find_objects_by_keyword("nonexistent");
         REQUIRE(nonexistent_results.empty());
     }
-    
+
     SECTION("Take and drop commands would work with keywords") {
         // This section validates that the system supports the functionality
         // needed for take/drop commands to work with keywords
-        
+
         // Verify objects start in room
         REQUIRE(room->contents().objects.size() == 2);
         REQUIRE(player->inventory().empty());
-        
+
         // Test that we can find objects by all their keywords
         auto room_objects = room->contents().objects;
-        
+
         // Find bread object and test all its keywords
         std::shared_ptr<Object> bread_obj = nullptr;
         std::shared_ptr<Object> sword_obj = nullptr;
-        
+
         for (const auto& obj : room_objects) {
             if (obj->id() == EntityId{3010}) {
                 bread_obj = obj;
@@ -144,64 +144,64 @@ TEST_CASE("Object Interaction Integration Test", "[integration][objects][command
                 sword_obj = obj;
             }
         }
-        
+
         REQUIRE(bread_obj != nullptr);
         REQUIRE(sword_obj != nullptr);
-        
+
         // Test bread object keyword matching (what take/drop commands use)
-        REQUIRE(bread_obj->matches_keyword("bread"));  // take bread
-        REQUIRE(bread_obj->matches_keyword("loaf"));   // take loaf  
-        REQUIRE(bread_obj->matches_keyword("food"));   // take food
-        REQUIRE_FALSE(bread_obj->matches_keyword("sword"));
-        
+        REQUIRE(bread_obj->matches_target_string("bread"));  // take bread
+        REQUIRE(bread_obj->matches_target_string("loaf"));   // take loaf
+        REQUIRE(bread_obj->matches_target_string("food"));   // take food
+        REQUIRE_FALSE(bread_obj->matches_target_string("sword"));
+
         // Test sword object keyword matching (what take/drop commands use)
-        REQUIRE(sword_obj->matches_keyword("sword"));   // take sword
-        REQUIRE(sword_obj->matches_keyword("blade"));   // take blade
-        REQUIRE(sword_obj->matches_keyword("weapon"));  // take weapon
-        REQUIRE_FALSE(sword_obj->matches_keyword("bread"));
-        
+        REQUIRE(sword_obj->matches_target_string("sword"));   // take sword
+        REQUIRE(sword_obj->matches_target_string("blade"));   // take blade
+        REQUIRE(sword_obj->matches_target_string("weapon"));  // take weapon
+        REQUIRE_FALSE(sword_obj->matches_target_string("bread"));
+
         // Test case insensitive matching (important for user commands)
-        REQUIRE(bread_obj->matches_keyword("BREAD"));
-        REQUIRE(bread_obj->matches_keyword("Loaf"));
-        REQUIRE(sword_obj->matches_keyword("SWORD"));
-        REQUIRE(sword_obj->matches_keyword("Weapon"));
-        
+        REQUIRE(bread_obj->matches_target_string("BREAD"));
+        REQUIRE(bread_obj->matches_target_string("Loaf"));
+        REQUIRE(sword_obj->matches_target_string("SWORD"));
+        REQUIRE(sword_obj->matches_target_string("Weapon"));
+
         // Test that inventory operations would work
         // (Simulating what the take command does)
         auto add_result = player->inventory().add_item(bread_obj);
         REQUIRE(add_result.has_value());
         REQUIRE(player->inventory().item_count() == 1);
-        
+
         // Test that we can find the item in inventory by keywords
         auto inventory_items = player->inventory().get_all_items();
         bool found_by_bread = false;
         bool found_by_loaf = false;
         bool found_by_food = false;
-        
+
         for (const auto& item : inventory_items) {
-            if (item->matches_keyword("bread")) found_by_bread = true;
-            if (item->matches_keyword("loaf")) found_by_loaf = true;
-            if (item->matches_keyword("food")) found_by_food = true;
+            if (item->matches_target_string("bread")) found_by_bread = true;
+            if (item->matches_target_string("loaf")) found_by_loaf = true;
+            if (item->matches_target_string("food")) found_by_food = true;
         }
-        
+
         REQUIRE(found_by_bread);
         REQUIRE(found_by_loaf);
         REQUIRE(found_by_food);
-        
+
         // Test that we can remove by object (what drop command does)
         REQUIRE(player->inventory().remove_item(bread_obj));
         REQUIRE(player->inventory().empty());
     }
-    
+
     SECTION("Object display names use short descriptions") {
         auto room_objects = room->contents().objects;
-        
+
         for (const auto& obj : room_objects) {
             if (obj->id() == EntityId{3010}) {
                 // Bread should display as "some bread"
                 std::string display_name = obj->display_name(false);
                 REQUIRE(display_name == "some bread");
-                
+
                 std::string display_name_with_article = obj->display_name(true);
                 REQUIRE(display_name_with_article == "some bread"); // "some" already implies article
             }
@@ -209,26 +209,26 @@ TEST_CASE("Object Interaction Integration Test", "[integration][objects][command
                 // Sword should display as "a sharp sword"
                 std::string display_name = obj->display_name(false);
                 REQUIRE(display_name == "a sharp sword");
-                
+
                 std::string display_name_with_article = obj->display_name(true);
                 REQUIRE(display_name_with_article == "a sharp sword"); // "a" already present
             }
         }
     }
-    
+
     SECTION("JSON round-trip preserves short descriptions and keywords") {
         // Test that objects can be serialized and deserialized correctly
         auto room_objects = room->contents().objects;
-        
+
         for (const auto& obj : room_objects) {
             // Serialize to JSON
             nlohmann::json json = obj->to_json();
-            
+
             // Verify JSON contains expected fields
             REQUIRE(json.contains("short"));
             REQUIRE(json.contains("keywords"));
             REQUIRE(json.contains("id"));
-            
+
             if (obj->id() == EntityId{3010}) {
                 REQUIRE(json["short"] == "some bread");
                 // Keywords should be parsed from name during object creation
@@ -237,20 +237,20 @@ TEST_CASE("Object Interaction Integration Test", "[integration][objects][command
                 REQUIRE(std::find(keywords.begin(), keywords.end(), "loaf") != keywords.end());
                 REQUIRE(std::find(keywords.begin(), keywords.end(), "food") != keywords.end());
             }
-            
+
             // Deserialize from JSON
             auto recreated_result = Object::from_json(json);
             REQUIRE(recreated_result.has_value());
             auto recreated = std::move(recreated_result.value());
-            
+
             // Verify recreated object matches original
             REQUIRE(recreated->id() == obj->id());
             REQUIRE(recreated->short_description() == obj->short_description());
             REQUIRE(recreated->name() == obj->name());
-            
+
             // Verify keywords work the same
             for (const std::string& keyword : obj->keywords()) {
-                REQUIRE(recreated->matches_keyword(keyword));
+                REQUIRE(recreated->matches_target_string(keyword));
             }
         }
     }
@@ -268,28 +268,28 @@ TEST_CASE("Object Loading from JSON with keywords field", "[unit][objects][json]
             {"weight", 1},
             {"value", 5}
         };
-        
+
         auto result = Object::from_json(json);
         REQUIRE(result.has_value());
         auto object = std::move(result.value());
-        
+
         // Verify object properties
         REQUIRE(object->id() == EntityId{3010});
         REQUIRE(object->name() == "bread loaf food");
         REQUIRE(object->short_description() == "some bread");
         REQUIRE(object->description() == "A fresh loaf of bread.");
-        
+
         // Verify keywords parsed from keywords field
-        REQUIRE(object->matches_keyword("bread"));
-        REQUIRE(object->matches_keyword("loaf"));
-        REQUIRE(object->matches_keyword("food"));
-        REQUIRE_FALSE(object->matches_keyword("sword"));
-        
+        REQUIRE(object->matches_target_string("bread"));
+        REQUIRE(object->matches_target_string("loaf"));
+        REQUIRE(object->matches_target_string("food"));
+        REQUIRE_FALSE(object->matches_target_string("sword"));
+
         // Verify case insensitive matching
-        REQUIRE(object->matches_keyword("BREAD"));
-        REQUIRE(object->matches_keyword("Loaf"));
+        REQUIRE(object->matches_target_string("BREAD"));
+        REQUIRE(object->matches_target_string("Loaf"));
     }
-    
+
     SECTION("Object loads correctly from JSON with legacy name_list") {
         // Test backward compatibility with legacy name_list format
         nlohmann::json json = {
@@ -299,22 +299,22 @@ TEST_CASE("Object Loading from JSON with keywords field", "[unit][objects][json]
             {"short_description", "a red apple"},
             {"description", "A crisp red apple."}
         };
-        
+
         auto result = Object::from_json(json);
         REQUIRE(result.has_value());
         auto object = std::move(result.value());
-        
-        // Verify object properties  
+
+        // Verify object properties
         REQUIRE(object->id() == EntityId{3011});
         REQUIRE(object->name() == "apple fruit snack");
         REQUIRE(object->short_description() == "a red apple");
-        
+
         // Verify keywords parsed from legacy name_list
-        REQUIRE(object->matches_keyword("apple"));
-        REQUIRE(object->matches_keyword("fruit"));
-        REQUIRE(object->matches_keyword("snack"));
+        REQUIRE(object->matches_target_string("apple"));
+        REQUIRE(object->matches_target_string("fruit"));
+        REQUIRE(object->matches_target_string("snack"));
     }
-    
+
     SECTION("Object loads correctly from JSON with explicit keywords array") {
         nlohmann::json json = {
             {"id", "3020"},
@@ -324,16 +324,16 @@ TEST_CASE("Object Loading from JSON with keywords field", "[unit][objects][json]
             {"short_description", "a gleaming sword"},
             {"description", "A finely crafted steel sword."}
         };
-        
+
         auto result = Object::from_json(json);
         REQUIRE(result.has_value());
         auto object = std::move(result.value());
-        
+
         // Verify keywords from explicit array
-        REQUIRE(object->matches_keyword("sword"));
-        REQUIRE(object->matches_keyword("blade"));
-        REQUIRE(object->matches_keyword("weapon"));
-        REQUIRE(object->matches_keyword("steel"));
-        REQUIRE_FALSE(object->matches_keyword("bread"));
+        REQUIRE(object->matches_target_string("sword"));
+        REQUIRE(object->matches_target_string("blade"));
+        REQUIRE(object->matches_target_string("weapon"));
+        REQUIRE(object->matches_target_string("steel"));
+        REQUIRE_FALSE(object->matches_target_string("bread"));
     }
 }


### PR DESCRIPTION
~~In v2, hyphenated keywords allowed you to match an entity's name starting at the beginning or after any `-` character.~~

~~v3's implementation only supported prefix matching at the very beginning of the name, making it a downgrade. Worse, most of the commands that have been implemented already weren't using the prefix-matching version of the function.~~

~~I unified `matches_keyword` and `matches_keyword_prefix` into a single function with an optional `match_prefix` parameter. Within this function, the parameter is broken into individual words which each must match one of the entity's keywords (or a prefix thereof). If any word doesn't match, the entire function returns `false`.~~

So while I was working on this, @stridera implemented the same thing in a somewhat different way. Whoops.

That said, there was still some value in the work I had done, so I've unified his work with mine.

* This PR optimizes the implementation of `matches_target_string` (see below).
* I also added a `matches_all_keywords` function that uses the same strategy, but it accepts pre-parsed input, so searching everything in the room and in your inventory doesn't have to redo the parsing work for every possible entity that could match. (It could probably be improved a step further by having `find_actor_target`/`find_object_target` take pre-parsed data but since that's O(k) I didn't think it was worth the effort.)
* I updated a bunch of command implementations to use `matches_target_string` that Strider hadn't gotten around to yet.
* I added some unit tests!

### Implementation note

I switched from `unordered_set` to `set` because `set::lower_bound` enables the prefix matching to be done in O(log n) time instead of O(n). While this does _theoretically_ reduce the efficiency of an exact match from O(1) to O(log n), the overhead of hashing the input makes this a fairly negligible difference for small sets.

In doing so, I also took out the short-circuit check for an exact match in `matches_keyword_prefix`. `set::lower_bound` will return the exact match in O(log n) time if it exists, and you no longer need to guard against an O(n) algorithm.

### TODO

I noticed `ExtraDescription::matches_keyword` and considered refactoring it to share an implementation, but because `EntityUtils::matches_keyword` expects a set instead of a vector, that modification seemed a bit too large of scope for this PR.

~~Strider's introduction of `matches_target_string` accidentally broke the liquid container special-case, because he didn't reimplement the override behavior. I didn't fix that in this PR. It might be a better idea to just add the liquid keyword to `keyword_set_` instead of using a virtual method, since the extra parsing work that `Object::matches_keyword` is doing is obsoleted by `matches_target_string`.~~ I went ahead and made this change.

### Review note

Turn on the "hide whitespace" option in the PR review UI. My editor strips trailing whitespace and there was a lot, so that toggle will reduce the noise.