### PR TITLE
Glory rework

### DIFF
--- a/src/act.movement.cpp
+++ b/src/act.movement.cpp
@@ -12,6 +12,7 @@
 
 #include "act.hpp"
 
+#include "ai.hpp"
 #include "board.hpp"
 #include "casting.hpp"
 #include "charsize.hpp"
@@ -599,6 +600,10 @@ bool do_simple_move(CharData *ch, int dir, int need_specials_check) {
      * gets added beyond this point. The trigger may kill the actor. */
     if (DECEASED(actor))
         return true;
+
+    if (was_in != IN_ROOM(actor)) {
+        queue_glory_event(actor);
+    }
 
     return true;
 }
@@ -1734,7 +1739,7 @@ ACMD(do_drag) {
             act("&3Your meditation is interrupted as %N grabs you.&0", false, ch, 0, 0, TO_CHAR);
             if (IS_NPC(ch))
                 REMOVE_FLAG(MOB_FLAGS(ch), MOB_MEDITATE);
-            else 
+            else
                 REMOVE_FLAG(PLR_FLAGS(ch), PLR_MEDITATE);
         }
 

--- a/src/ai.hpp
+++ b/src/ai.hpp
@@ -14,6 +14,7 @@
 #include "skills.hpp"
 #include "structs.hpp"
 #include "sysdep.hpp"
+#include <vector>
 
 #define MOB_ASSISTER(ch)                                                                                               \
     (!MOB_FLAGGED((ch), MOB_PEACEFUL) &&                                                                               \
@@ -34,9 +35,14 @@ void perform_remove(CharData *ch, int pos);
 int appraise_item(CharData *ch, ObjData *obj);
 bool will_assist(CharData *ch, CharData *vict);
 CharData *find_aggr_target(CharData *ch);
-void glorion_distraction(CharData *ch, CharData *glorion);
 int appraise_opponent(CharData *ch, CharData *vict);
 bool is_aggr_to(CharData *ch, CharData *tch);
+
+std::vector<CharData*> find_glorions(CharData* mob);
+void glorion_distraction(CharData *ch, CharData *glorion);
+void check_glory(CharData* ch, CharData* caster = nullptr);
+void check_glory_around(CharData* ch);
+void queue_glory_event(CharData* ch);
 
 /* Class AI functions */
 bool sorcerer_ai_action(CharData *ch, CharData *victim);

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -64,6 +64,7 @@ const char *eventnames[MAX_EVENT + 1] = {"!INVALID EVENT!", /* 0 - reserved */
                                          "command",
                                          "start_editor",
                                          "get_money", /* 30 */
+                                         "witness_glory",
                                          "\n"};
 
 /*************************************************************************/

--- a/src/events.hpp
+++ b/src/events.hpp
@@ -85,8 +85,9 @@ void delayed_command(CharData *ch, char *command, int delay, bool repeatable);
 #define EVENT_COMMAND 28
 #define EVENT_EDITOR_START 29
 #define EVENT_GET_MONEY 30
+#define EVENT_WITNESS_GLORY 31
 /* Update MAX_EVENT to be last event value + 1, please */
-#define MAX_EVENT 31
+#define MAX_EVENT 32
 
 EVENTFUNC(extract_event);
 EVENTFUNC(hurt_event);

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -12,6 +12,7 @@
 
 #include "magic.hpp"
 
+#include "ai.hpp"
 #include "casting.hpp"
 #include "chars.hpp"
 #include "charsize.hpp"
@@ -3347,6 +3348,10 @@ int mag_affect(int skill, CharData *ch, CharData *victim, int spellnum, int save
             act(to_room, true, ch, 0, victim, TO_NOTVICT);
             if (to_char == nullptr && ch != victim)
                 act(to_room, false, ch, 0, victim, TO_CHAR);
+        }
+
+        if (spellnum == SPELL_GLORY) {
+            queue_glory_event(ch);
         }
     } else {
         /* Add generic refresh message */


### PR DESCRIPTION
Per @daedela:
> Glory doesn't work quite as intended.  It's supposed to check each mob in a given room and override and prevent any aggro flags.  But it's supposed to have a small chance for ANY mob in the room to attack the Gloried person.
> 
> The problem is instead of checking every mob and placing a flag that should block aggro which is removed when the Glory user leaves the room, it checks every mob every tick.  Which means eventually it's going to land on "kill on sight" for every mob in the room.  So suddenly you're being attacked by everything in sight, rather than stopping aggro mobs from aggroing

This PR replaces the Glory check in the aggro code with:

* On spell cast or when player moves:
    * Iterate over mobs in room
    * Roll for instant aggro
* When mob moves:
    * Iterate over characters in destination room
    * If Glory found, roll for instant aggro
* When mob checks for aggro:
    * Iterate over characters in room
    * If Glory found, cancel aggro check

The idea is that you really only need to check for a random attack the first time the mob enters the area of effect. After that, either the fight is already happening, or a fight won't happen, so glory should cause subsequent aggro checks to abort.