### PR TITLE
fix color command

### DIFF
--- a/src/act.informative.cpp
+++ b/src/act.informative.cpp
@@ -2683,7 +2683,7 @@ ACMD(do_color) {
         char_printf(ch, "Your current color level is {}.\n", ctypes[COLOR_LEV(ch)]);
         return;
     }
-    if ((tp = searchblock(arg, ctypes, false) == -1)) {
+    if ((tp = searchblock(arg, ctypes, false)) == -1) {
         char_printf(ch, "Usage: color { Off | Sparse | Normal | Complete }\n");
         return;
     }


### PR DESCRIPTION
About a year ago, a code cleanup accidentally got the parentheses wrong in the `color` command that almost nobody uses.

_Almost._